### PR TITLE
Use flat mode for BrowserRecorder when in Agregore

### DIFF
--- a/src/ext/browser-recorder.js
+++ b/src/ext/browser-recorder.js
@@ -9,7 +9,7 @@ const DEBUG = false;
 
 const hasInfoBar = (self.chrome && self.chrome.braveWebrecorder != undefined);
 
-const IS_AGREGORE = navigator.userAgent.includes("AgregoreDesktop");
+const IS_AGREGORE = navigator.userAgent.includes("agregore-browser");
 
 
 // ===========================================================================

--- a/src/ext/browser-recorder.js
+++ b/src/ext/browser-recorder.js
@@ -9,6 +9,8 @@ const DEBUG = false;
 
 const hasInfoBar = (self.chrome && self.chrome.braveWebrecorder != undefined);
 
+const IS_AGREGORE = navigator.userAgent.includes("AgregoreDesktop");
+
 
 // ===========================================================================
 class BrowserRecorder extends Recorder {
@@ -22,6 +24,8 @@ class BrowserRecorder extends Recorder {
     this.tabId = debuggee.tabId;
     this.openWinMap = openWinMap;
     this.autorun = autorun;
+
+    this.flatMode = IS_AGREGORE;
 
     this.collLoader = collLoader;
     this.setCollId(collId);
@@ -86,7 +90,7 @@ class BrowserRecorder extends Recorder {
 
   _doStop() {
     //chrome.tabs.sendMessage(this.tabId, {"msg": "stopRecord"});
-    
+
     chrome.debugger.onDetach.removeListener(this._onDetached);
     chrome.debugger.onEvent.removeListener(this._onEvent);
 
@@ -280,6 +284,15 @@ class BrowserRecorder extends Recorder {
     chrome.debugger.sendCommand(this.debuggee, method, params, callback);
     return promise;
   }
+
+  _doSendCommandFlat(method, params, sessionId) {
+    try {
+      return chrome.debugger.sendCommand(this.debugee, method, params, sessionId);
+    } catch(e) {
+      console.warn(e);
+    }
+  }
+
 
   handleWindowOpen(url, sessions) {
     super.handleWindowOpen(url, sessions);

--- a/src/ext/browser-recorder.js
+++ b/src/ext/browser-recorder.js
@@ -52,10 +52,11 @@ class BrowserRecorder extends Recorder {
       }
     };
 
-    this._onEvent = async (tab, message, params) => {
+    this._onEvent = async (tab, message, params, sessionId) => {
       if (this.tabId === tab.tabId) {
         try {
-          await this.processMessage(message, params, []);
+          const sessions = sessionId ? [sessionId] : [];
+          await this.processMessage(message, params, sessions);
         } catch (e) {
           console.warn(e);
           console.log(message);

--- a/src/ext/browser-recorder.js
+++ b/src/ext/browser-recorder.js
@@ -292,7 +292,7 @@ class BrowserRecorder extends Recorder {
     }
 
     try {
-      return chrome.debugger.sendCommand(this.debugee, method, params, sessionId);
+      return chrome.debugger.sendCommand(this.debuggee, method, params, sessionId);
     } catch(e) {
       console.warn(e);
     }

--- a/src/ext/browser-recorder.js
+++ b/src/ext/browser-recorder.js
@@ -286,6 +286,10 @@ class BrowserRecorder extends Recorder {
   }
 
   _doSendCommandFlat(method, params, sessionId) {
+    if (DEBUG) {
+      console.log("SEND " + JSON.stringify({command: method, params}));
+    }
+
     try {
       return chrome.debugger.sendCommand(this.debugee, method, params, sessionId);
     } catch(e) {


### PR DESCRIPTION
Also noticed that `eslint` wasn't in the dev dependencies. Might submit a follow-up PR to enable it.

_doSendCommandFlat copied from the electron version, using promises instead of callbacks since this is only relevent within Agregore which supports promises for extension APIs.