### PR TITLE
Add issue templates to GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: If something isn't working as expected and you're sure your issue is reproducible, please file this type of issue!
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  # Version number
+  - type: input
+    id: version
+    attributes:
+      label: ArchiveWeb.page Version
+      description: "This can be found on the app home page under \"About\""
+      placeholder: "v0.11.3"
+    validations:
+      required: true
+  # What did the user expect to happen? What was the actual behavior?
+  - type: textarea
+    attributes:
+      label: What did you expect to happen? What happened instead?
+      description: |
+        "I was trying to archive a page however..."
+
+        Please submit any screenshots/videos that can be used to understand how to reproduce the issue. You can attach images by clicking this area to highlight it and then dragging files into the browser window.
+        
+        If something wasn't captured in the way you expect please include a link to the archived item if possible.
+    validations:
+      required: true
+  # Step-by-step reproduction instructions
+  - type: textarea
+    attributes:
+      label: Step-by-step reproduction instructions
+      placeholder: |
+        1. Navigate to...
+        2. Click on...
+        3. See error...
+    validations:
+      required: true
+  # Additional details
+  - type: textarea
+    attributes:
+      label: Additional details
+      description: Add any other relevant information here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Allow issues to be created without a template
+blank_issues_enabled: true
+
+contact_links:
+  - name: Report a replay issue
+    about: Issues related to archived content not displaying properly should be reported in the ReplayWeb.page repo.
+    url: https://github.com/webrecorder/replayweb.page/issues/new?&labels=replay+bug%2Cbug&projects=&template=replay-bug.yml&title=[Replay+Bug]%3A+
+  - name: Report a security vulnerability
+    about: Please do not file an issue and instead email security@webrecorder.org. We will follow up with you there!
+    url: https://webrecorder.net/.well-known/security.txt
+  - name: Get help on our forum
+    url: https://forum.webrecorder.net/
+    about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The best way to get help is on our community forum!
+  - name: Check out the docs
+    url: https://archiveweb.page/guide
+    about: Solutions to common questions may be available in the documentation!

--- a/.github/ISSUE_TEMPLATE/feature-change.yml
+++ b/.github/ISSUE_TEMPLATE/feature-change.yml
@@ -1,0 +1,48 @@
+name: Feature / Change Request
+description: If new things should be added or something that is working as intended should be changed, please file this type of issue!
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  # Context
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe any prior information that we are taking into account to inform this future development.
+      placeholder: "Now that x is done we should do y to accomplish z."
+    validations:
+      required: true
+  # User story sentence
+  - type: textarea
+    attributes:
+      label: What change would you like to see?
+      description: Describe the solution you'd like. If relevant, include ways in which you've tried to solve the issue with the current version.
+      placeholder: "As a user, I want to be able to ____ so that I can ____"
+    validations:
+      required: true
+  # Requirements
+  - type: textarea
+    attributes:
+      label: Requirements
+      description: |
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
+        
+        List the outcomes of the feature being implemented without design or implementation details.
+      placeholder: |
+        1. Item metadata should show links to the collections that the item belongs to.
+        2. Items can be added or removed from collections when editing an item.
+    validations:
+      required: false
+  # Todo
+  - type: textarea
+    attributes:
+      label: Todo
+      description: |
+        Intended primarily for use by Webrecorder team, leave blank if unknown.
+
+        Any other linked issues / tasks to complete to implement this feature.
+      placeholder: |
+        - [ ] Mockups: 
+        - [ ] Design: 
+        - [ ] UI: 
+    validations:
+      required: false


### PR DESCRIPTION
Fixes #202

Adds our issue templates over here!

Mostly copied from Browsertrix with minor changes to reflect the extension.