### PR TITLE
Include POST data even if its is empty

### DIFF
--- a/src/requestresponseinfo.js
+++ b/src/requestresponseinfo.js
@@ -183,12 +183,12 @@ class RequestResponseInfo
 
     const reqUrl = this.url;
 
-    if (this.postData) {
+    if (this.method && this.method !== "GET") {
       const convData = {
         url: this.url,
         headers: reqHeaders.headers,
         method: this.method,
-        postData: this.postData,
+        postData: this.postData || "",
       };
       if (postToGetUrl(convData)) {
         //this.requestBody = convData.requestBody;


### PR DESCRIPTION
Currently, empty POST body for a POST request was being dropped, resulting in it being treated as a GET.
This isn't quite right (and wabac.js now handle this correctly with webrecorder/wabac.js#159), will save the request as a POST with an empty body.
