### PR TITLE
facebook fix + configurable storage/cookie archiving

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.1",
-    "@webrecorder/awp-sw": "^0.5.0",
-    "@webrecorder/wabac": "^2.20.3",
+    "@webrecorder/awp-sw": "^0.5.1",
+    "@webrecorder/wabac": "^2.20.4",
     "auto-js-ipfs": "^2.3.0",
     "browsertrix-behaviors": "^0.6.4",
     "btoa": "^1.2.1",
@@ -31,7 +31,7 @@
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "unused-filename": "^4.0.1",
     "uuid": "^8.3.2",
-    "warcio": "^2.3.1"
+    "warcio": "^2.4.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -64,7 +64,7 @@
     "webpack-extension-reloader": "^1.1.4"
   },
   "resolutions": {
-    "@webrecorder/wabac": "^2.20.3"
+    "@webrecorder/wabac": "^2.20.4"
   },
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.1",
-    "@webrecorder/awp-sw": "^0.5.1",
+    "@webrecorder/awp-sw": "^0.5.2",
     "@webrecorder/wabac": "^2.20.5",
     "auto-js-ipfs": "^2.3.0",
     "browsertrix-behaviors": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.1",
     "@webrecorder/awp-sw": "^0.5.1",
-    "@webrecorder/wabac": "^2.20.4",
+    "@webrecorder/wabac": "^2.20.5",
     "auto-js-ipfs": "^2.3.0",
     "browsertrix-behaviors": "^0.6.4",
     "btoa": "^1.2.1",
@@ -64,7 +64,7 @@
     "webpack-extension-reloader": "^1.1.4"
   },
   "resolutions": {
-    "@webrecorder/wabac": "^2.20.4"
+    "@webrecorder/wabac": "^2.20.5"
   },
   "files": [
     "src/",

--- a/src/localstorage.ts
+++ b/src/localstorage.ts
@@ -19,11 +19,10 @@ export function setLocalOption(name, value) {
 }
 
 // ===========================================================================
-// @ts-expect-error - TS7006 - Parameter 'name' implicitly has an 'any' type.
-export function getLocalOption(name) {
+export function getLocalOption(name: string) : Promise<string | null> {
   // @ts-expect-error - TS2339 - Property 'chrome' does not exist on type 'Window & typeof globalThis'. | TS2339 - Property 'chrome' does not exist on type 'Window & typeof globalThis'.
   if (self.chrome?.storage) {
-    return new Promise((resolve) => {
+    return new Promise<string>((resolve) => {
       // @ts-expect-error - TS2339 - Property 'chrome' does not exist on type 'Window & typeof globalThis'.
       self.chrome.storage.local.get(name, (res) => {
         resolve(res[name]);
@@ -35,7 +34,7 @@ export function getLocalOption(name) {
     return Promise.resolve(localStorage.getItem(name));
   }
 
-  return Promise.reject();
+  return Promise.reject(null);
 }
 
 // ===========================================================================

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1818,10 +1818,6 @@ class Recorder {
       // @ts-expect-error - TS2339 - Property 'payload' does not exist on type 'RequestResponseInfo'.
       reqresp.payload = new Uint8Array(payload);
 
-      if (request.rangeRemoved) {
-        reqresp.extraOpts["rangeRemoved"] = "1";
-      }
-
       const data = reqresp.toDBRecord(
         // @ts-expect-error - TS2339 - Property 'payload' does not exist on type 'RequestResponseInfo'.
         reqresp.payload,

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1,6 +1,11 @@
 import { RequestResponseInfo } from "./requestresponseinfo";
 
-import { getCustomRewriter, rewriteDASH, rewriteHLS } from "@webrecorder/wabac";
+import {
+  getCustomRewriter,
+  rewriteDASH,
+  rewriteHLS,
+  removeRangeAsQuery,
+} from "@webrecorder/wabac";
 
 import { Buffer } from "buffer";
 
@@ -15,6 +20,7 @@ import {
   BEHAVIOR_PAUSED,
   BEHAVIOR_DONE,
 } from "./consts";
+import { getLocalOption } from "./localstorage";
 
 // @ts-expect-error - TS2554 - Expected 0 arguments, but got 1.
 const encoder = new TextEncoder("utf-8");
@@ -34,9 +40,26 @@ function sleep(time) {
   return new Promise((resolve) => setTimeout(() => resolve(), time));
 }
 
+type FetchEntry = {
+  url: string;
+  headers?: Headers;
+  rangeReplaced?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sessions?: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pageInfo?: any;
+
+  rangeRemoved?: boolean;
+  doRangeCheck?: boolean;
+  redirectOnly?: boolean;
+};
+
 // ===========================================================================
 class Recorder {
-  recordStorage = true;
+  archiveStorage = false;
+  archiveCookies = false;
+
+  _fetchQueue: FetchEntry[] = [];
 
   constructor() {
     // @ts-expect-error - TS2339 - Property 'flatMode' does not exist on type 'Recorder'.
@@ -79,8 +102,7 @@ class Recorder {
 
     // @ts-expect-error - TS2339 - Property '_fetchPending' does not exist on type 'Recorder'.
     this._fetchPending = new Map();
-    // @ts-expect-error - TS2339 - Property '_fetchQueue' does not exist on type 'Recorder'.
-    this._fetchQueue = [];
+
     // @ts-expect-error - TS2339 - Property '_fetchUrls' does not exist on type 'Recorder'.
     this._fetchUrls = new Set();
 
@@ -128,6 +150,13 @@ class Recorder {
     this.defaultFetchOpts = {
       redirect: "manual",
     };
+
+    this.initOpts();
+  }
+
+  async initOpts() {
+    this.archiveCookies = (await getLocalOption("archiveCookies") === "1");
+    this.archiveStorage = (await getLocalOption("archiveStorage") === "1");
   }
 
   // @ts-expect-error - TS7006 - Parameter 'autorun' implicitly has an 'any' type.
@@ -860,7 +889,7 @@ class Recorder {
   // @ts-expect-error - TS7006 - Parameter 'url' implicitly has an 'any' type. | TS7006 - Parameter 'sessions' implicitly has an 'any' type.
   handleWindowOpen(url, sessions) {
     // @ts-expect-error - TS2339 - Property 'pageInfo' does not exist on type 'Recorder'.
-    const headers = { Referer: this.pageInfo.url };
+    const headers = new Headers({ Referer: this.pageInfo.url });
     this.doAsyncFetch({ url, headers, redirectOnly: true }, sessions);
   }
 
@@ -1450,8 +1479,12 @@ class Recorder {
     //this._fetchPending.set(requestId, pending);
 
     try {
-      // @ts-expect-error - TS2339 - Property 'pageInfo' does not exist on type 'Recorder'.
-      const data = reqresp.toDBRecord(reqresp.payload, this.pageInfo);
+      const data = reqresp.toDBRecord(
+        reqresp.payload,
+        // @ts-expect-error - TS2339 - Property 'pageInfo' does not exist on type 'Recorder'.
+        this.pageInfo,
+        this.archiveCookies,
+      );
 
       // top-level URL is a non-GET request
       if (
@@ -1513,7 +1546,7 @@ class Recorder {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getStorage(sessions: any) {
     // check if recording storage is allowed
-    if (!this.recordStorage) {
+    if (!this.archiveStorage) {
       return null;
     }
 
@@ -1576,7 +1609,7 @@ class Recorder {
 
       reqresp.fillResponseRedirect(params);
       // @ts-expect-error - TS2339 - Property 'pageInfo' does not exist on type 'Recorder'.
-      data = reqresp.toDBRecord(null, this.pageInfo);
+      data = reqresp.toDBRecord(null, this.pageInfo, this.archiveCookies);
     }
 
     reqresp.fillRequest(params);
@@ -1629,14 +1662,14 @@ class Recorder {
     for (const { value } of params.events) {
       if (value.indexOf('"kLoad"') > 0) {
         const { url } = JSON.parse(value);
-        this.doAsyncFetch({ url }, sessions);
+        this.doAsyncFetch({ url, doRangeCheck: true }, sessions);
         break;
       }
     }
   }
 
   // @ts-expect-error - TS7006 - Parameter 'request' implicitly has an 'any' type. | TS7006 - Parameter 'resp' implicitly has an 'any' type.
-  async attemptFetchRedirect(request, resp) {
+  async attemptFetchRedirect(request: FetchEntry, resp) {
     if (request.redirectOnly && resp.type === "opaqueredirect") {
       const abort = new AbortController();
       // @ts-expect-error - TS2345 - Argument of type '{ abort: AbortController; }' is not assignable to parameter of type 'RequestInit'.
@@ -1671,9 +1704,17 @@ class Recorder {
   }
 
   // @ts-expect-error - TS7006 - Parameter 'request' implicitly has an 'any' type. | TS7006 - Parameter 'sessions' implicitly has an 'any' type.
-  doAsyncFetch(request, sessions) {
+  doAsyncFetch(request: FetchEntry, sessions) {
     if (!request || !this.isValidUrl(request.url)) {
       return;
+    }
+
+    if (request.doRangeCheck) {
+      const url = removeRangeAsQuery(request.url);
+      if (url) {
+        request.url = url;
+        request.rangeRemoved = true;
+      }
     }
 
     // @ts-expect-error - TS2339 - Property '_fetchUrls' does not exist on type 'Recorder'.
@@ -1686,7 +1727,6 @@ class Recorder {
     request.pageInfo = this.pageInfo;
     request.sessions = sessions;
 
-    // @ts-expect-error - TS2339 - Property '_fetchQueue' does not exist on type 'Recorder'.
     this._fetchQueue.push(request);
 
     this.doBackgroundFetch();
@@ -1694,7 +1734,6 @@ class Recorder {
 
   async doBackgroundFetch() {
     if (
-      // @ts-expect-error - TS2339 - Property '_fetchQueue' does not exist on type 'Recorder'.
       !this._fetchQueue.length ||
       // @ts-expect-error - TS2339 - Property '_fetchPending' does not exist on type 'Recorder'.
       this._fetchPending.size >= MAX_CONCURRENT_FETCH ||
@@ -1704,8 +1743,10 @@ class Recorder {
       return;
     }
 
-    // @ts-expect-error - TS2339 - Property '_fetchQueue' does not exist on type 'Recorder'.
     const request = this._fetchQueue.shift();
+    if (!request) {
+      return;
+    }
 
     // @ts-expect-error - TS2339 - Property '_fetchUrls' does not exist on type 'Recorder'.
     if (this._fetchUrls.has(request.url)) {
@@ -1732,11 +1773,9 @@ class Recorder {
       // @ts-expect-error - TS2339 - Property 'defaultFetchOpts' does not exist on type 'Recorder'.
       const opts = { ...this.defaultFetchOpts };
 
-      if (request.getRequestHeadersDict) {
-        opts.headers = request.getRequestHeadersDict().headers;
-        opts.headers.delete("range");
-      } else if (request.headers) {
+      if (request.headers) {
         opts.headers = request.headers;
+        opts.headers.delete("range");
       }
 
       let resp = await fetch(request.url, opts);
@@ -1779,8 +1818,16 @@ class Recorder {
       // @ts-expect-error - TS2339 - Property 'payload' does not exist on type 'RequestResponseInfo'.
       reqresp.payload = new Uint8Array(payload);
 
-      // @ts-expect-error - TS2339 - Property 'payload' does not exist on type 'RequestResponseInfo'.
-      const data = reqresp.toDBRecord(reqresp.payload, request.pageInfo);
+      if (request.rangeRemoved) {
+        reqresp.extraOpts["rangeRemoved"] = "1";
+      }
+
+      const data = reqresp.toDBRecord(
+        // @ts-expect-error - TS2339 - Property 'payload' does not exist on type 'RequestResponseInfo'.
+        reqresp.payload,
+        request.pageInfo,
+        this.archiveCookies,
+      );
 
       if (data) {
         await this.commitResource(data, request.pageInfo);
@@ -1813,9 +1860,36 @@ class Recorder {
     let payload;
 
     if (reqresp.status === 206) {
-      sleep(500).then(() => this.doAsyncFetch(reqresp, sessions));
+      sleep(500).then(() =>
+        this.doAsyncFetch(
+          {
+            url: reqresp.url,
+            headers: reqresp.getRequestHeadersDict().headers,
+          },
+          sessions,
+        ),
+      );
       reqresp.payload = null;
       return null;
+    } else {
+      const changedUrl = removeRangeAsQuery(reqresp.url);
+
+      if (changedUrl) {
+        reqresp.url = changedUrl;
+        this.removeReqResp(reqresp.requestId);
+        sleep(500).then(() =>
+          this.doAsyncFetch(
+            {
+              url: changedUrl,
+              headers: reqresp.getRequestHeadersDict().headers,
+              rangeRemoved: true,
+            },
+            sessions,
+          ),
+        );
+        reqresp.payload = null;
+        return null;
+      }
     }
 
     if (!this.noResponseForStatus(reqresp.status)) {
@@ -1888,9 +1962,13 @@ class Recorder {
       if (reqresp.payload) {
         // @ts-expect-error - TS2571 - Object is of type 'unknown'.
         console.log(`Committing Finished ${id} - ${reqresp.url}`);
-
         // @ts-expect-error - TS2571 - Object is of type 'unknown'. | TS2571 - Object is of type 'unknown'.
-        const data = reqresp.toDBRecord(reqresp.payload, pageInfo);
+        const data = reqresp.toDBRecord(
+          // @ts-expect-error - TS2571 - Object is of type 'unknown'. | TS2571 - Object is of type 'unknown'.
+          reqresp.payload,
+          pageInfo,
+          this.archiveCookies,
+        );
 
         if (data) {
           // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.

--- a/src/requestresponseinfo.ts
+++ b/src/requestresponseinfo.ts
@@ -16,6 +16,8 @@ const encoder = new TextEncoder();
 
 // ===========================================================================
 class RequestResponseInfo {
+  extraOpts: Record<string, string>;
+
   // @ts-expect-error - TS7006 - Parameter 'requestId' implicitly has an 'any' type.
   constructor(requestId) {
     // @ts-expect-error - TS2339 - Property '_created' does not exist on type 'RequestResponseInfo'.
@@ -70,7 +72,6 @@ class RequestResponseInfo {
     // @ts-expect-error - TS2339 - Property 'resourceType' does not exist on type 'RequestResponseInfo'.
     this.resourceType = null;
 
-    // @ts-expect-error - TS2339 - Property 'extraOpts' does not exist on type 'RequestResponseInfo'.
     this.extraOpts = {};
   }
 
@@ -212,7 +213,7 @@ class RequestResponseInfo {
   }
 
   // @ts-expect-error - TS7006 - Parameter 'payload' implicitly has an 'any' type. | TS7006 - Parameter 'pageInfo' implicitly has an 'any' type.
-  toDBRecord(payload, pageInfo) {
+  toDBRecord(payload, pageInfo, allowCookies) {
     // don't save 304 (todo: turn into 'revisit' style entry?)
     // extra check for 206, should already be skipped
     if (
@@ -257,7 +258,11 @@ class RequestResponseInfo {
     const cookie = reqHeaders.headers.get("cookie");
 
     if (cookie) {
-      respHeaders.headersDict["x-wabac-preset-cookie"] = cookie;
+      if (allowCookies) {
+        respHeaders.headersDict["x-wabac-preset-cookie"] = cookie;
+      } else {
+        reqHeaders.headers.delete("cookie");
+      }
     }
 
     // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RequestResponseInfo'.
@@ -312,7 +317,6 @@ class RequestResponseInfo {
       mime,
       respHeaders: respHeaders.headersDict,
       reqHeaders: reqHeaders.headersDict,
-      // @ts-expect-error - TS2339 - Property 'extraOpts' does not exist on type 'RequestResponseInfo'.
       extraOpts: this.extraOpts,
     };
 

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -109,10 +109,13 @@ class ArchiveWebApp extends ReplayWebApp {
     this.autorun = (await getLocalOption("autorunBehaviors") === "1");
 
     const archiveCookies = await getLocalOption("archiveCookies");
+
     // default to true if unset to match existing behavior
     if (archiveCookies === null) {
       await setLocalOption("archiveCookies", "1");
       this.archiveCookies = true;
+    } else {
+      this.archiveCookies = archiveCookies === "1";
     }
 
     this.archiveStorage = await getLocalOption("archiveStorage") === "1";

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1426,14 +1426,14 @@ class ArchiveWebApp extends ReplayWebApp {
     const archiveStorage = this.renderRoot.querySelector("#archiveStorage");
 
     if (archiveCookies) {
-      self.localStorage.setItem(
+      await setLocalOption(
         "archiveCookies",
         (archiveCookies as HTMLInputElement).checked ? "1" : "0",
       );
     }
 
     if (archiveStorage) {
-      self.localStorage.setItem(
+      await setLocalOption(
         "archiveStorage",
         (archiveStorage as HTMLInputElement).checked ? "1" : "0",
       );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,7 +157,7 @@ function sharedBuild(
       sw: "./src/sw/main.ts",
       ...entry,
     },
-    devtool: argv.mode === "production" ? undefined : "source-map",
+    devtool: argv.mode === "production" ? undefined : "inline-source-map",
     optimization: argv.mode === "production" ? optimization : undefined,
     output: {
       path: outputPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,10 +2319,10 @@
     uuid "^9.0.0"
     warcio "^2.3.1"
 
-"@webrecorder/wabac@^2.20.3", "@webrecorder/wabac@^2.20.4":
-  version "2.20.4"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.4.tgz#aacc3038e92992fb58039107fe57dfdb41893542"
-  integrity sha512-OK9nMI03rDL+KEn5iT1TUKuz7AdjzeS3F0/5KTOWHp+QCN3ZvjABRLZYxa9LIGiEWKbVEvoG/oriFZntR3/VWw==
+"@webrecorder/wabac@^2.20.3", "@webrecorder/wabac@^2.20.4", "@webrecorder/wabac@^2.20.5":
+  version "2.20.5"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.5.tgz#bac841e278a318663dbb5935d5241cd043b40a82"
+  integrity sha512-2TfVJM0a319W+qWj/qocnYgF6lDaaeTotcPn6ZRqIUq70r8TXi8ZzIqpjYAxqGNkxCRapq/7Yo1/gDVIjVpD3Q==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,14 +2303,14 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/awp-sw@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@webrecorder/awp-sw/-/awp-sw-0.5.1.tgz#3894e5a2ee797225917bfc38c44348b0780b8fe8"
-  integrity sha512-hyGmlt+cZur7ig6AtAFLLTtWdXAmIE77C7Hitlo2+6krYagW71UaSA6O2W0ErweY7SlNcmqZOrxMSkYbSf6f1Q==
+"@webrecorder/awp-sw@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@webrecorder/awp-sw/-/awp-sw-0.5.2.tgz#3ed0b9f1de816a5d1f426c96ef3440527b35c982"
+  integrity sha512-q82K8P4Z0NRoOgDBB0reutLllUyh+H69RB1KM09GFN0wWDlZ1qmB8wXgM14MFilmWrQOEQEu9Muu7mhDT+FWsA==
   dependencies:
     "@ipld/car" "^5.3.2"
     "@ipld/unixfs" "^3.0.0"
-    "@webrecorder/wabac" "^2.20.4"
+    "@webrecorder/wabac" "^2.20.5"
     auto-js-ipfs "^2.3.0"
     client-zip "^2.3.0"
     hash-wasm "^4.9.0"
@@ -2319,7 +2319,7 @@
     uuid "^9.0.0"
     warcio "^2.3.1"
 
-"@webrecorder/wabac@^2.20.3", "@webrecorder/wabac@^2.20.4", "@webrecorder/wabac@^2.20.5":
+"@webrecorder/wabac@^2.20.3", "@webrecorder/wabac@^2.20.5":
   version "2.20.5"
   resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.5.tgz#bac841e278a318663dbb5935d5241cd043b40a82"
   integrity sha512-2TfVJM0a319W+qWj/qocnYgF6lDaaeTotcPn6ZRqIUq70r8TXi8ZzIqpjYAxqGNkxCRapq/7Yo1/gDVIjVpD3Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,9 +1150,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.5.1":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
-  integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
+  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
 
 "@eslint-community/regexpp@^4.6.1":
   version "4.11.1"
@@ -1929,9 +1929,9 @@
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
 
 "@types/semver@^7.5.0":
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
-  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/send@*":
   version "0.17.4"
@@ -2043,15 +2043,15 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^6.15.0":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz#b0b3e15fa8c3e67ed4386b765cc0ba98ad3a303b"
-  integrity sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz#30830c1ca81fd5f3c2714e524c4303e0194f9cd3"
+  integrity sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==
   dependencies:
     "@eslint-community/regexpp" "^4.5.1"
-    "@typescript-eslint/scope-manager" "6.15.0"
-    "@typescript-eslint/type-utils" "6.15.0"
-    "@typescript-eslint/utils" "6.15.0"
-    "@typescript-eslint/visitor-keys" "6.15.0"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/type-utils" "6.21.0"
+    "@typescript-eslint/utils" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
     debug "^4.3.4"
     graphemer "^1.4.0"
     ignore "^5.2.4"
@@ -2078,13 +2078,21 @@
     "@typescript-eslint/types" "6.15.0"
     "@typescript-eslint/visitor-keys" "6.15.0"
 
-"@typescript-eslint/type-utils@6.15.0":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz#c22261bd00566821a300d08f4632533a8f9bed01"
-  integrity sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==
+"@typescript-eslint/scope-manager@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
+  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
   dependencies:
-    "@typescript-eslint/typescript-estree" "6.15.0"
-    "@typescript-eslint/utils" "6.15.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+
+"@typescript-eslint/type-utils@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz#6473281cfed4dacabe8004e8521cee0bd9d4c01e"
+  integrity sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    "@typescript-eslint/utils" "6.21.0"
     debug "^4.3.4"
     ts-api-utils "^1.0.1"
 
@@ -2092,6 +2100,11 @@
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.15.0.tgz#a9f7b006aee52b0948be6e03f521814bf435ddd5"
   integrity sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==
+
+"@typescript-eslint/types@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
+  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
 
 "@typescript-eslint/typescript-estree@6.15.0":
   version "6.15.0"
@@ -2106,17 +2119,31 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@6.15.0":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.15.0.tgz#f80dbb79f3b0f569077a8711dd44186a8933fa4c"
-  integrity sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==
+"@typescript-eslint/typescript-estree@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz#c47ae7901db3b8bddc3ecd73daff2d0895688c46"
+  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/utils@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.21.0.tgz#4714e7a6b39e773c1c8e97ec587f520840cd8134"
+  integrity sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
     "@types/json-schema" "^7.0.12"
     "@types/semver" "^7.5.0"
-    "@typescript-eslint/scope-manager" "6.15.0"
-    "@typescript-eslint/types" "6.15.0"
-    "@typescript-eslint/typescript-estree" "6.15.0"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
     semver "^7.5.4"
 
 "@typescript-eslint/visitor-keys@6.15.0":
@@ -2125,6 +2152,14 @@
   integrity sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==
   dependencies:
     "@typescript-eslint/types" "6.15.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@typescript-eslint/visitor-keys@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz#87a99d077aa507e20e238b11d56cc26ade45fe47"
+  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
     eslint-visitor-keys "^3.4.1"
 
 "@ungap/structured-clone@^1.2.0":
@@ -2268,14 +2303,14 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/awp-sw@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@webrecorder/awp-sw/-/awp-sw-0.5.0.tgz#0e5d4979d9a3f48057ca6cc275a5a22641a50972"
-  integrity sha512-3sz9uBP4Ayvko1KHjzC40edZPdYSV5N8WUe6qfqnfdjzgV4jJ7D/kSax4N0CbD537rDNrxfXHKEt9+xSl6QfTQ==
+"@webrecorder/awp-sw@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@webrecorder/awp-sw/-/awp-sw-0.5.1.tgz#3894e5a2ee797225917bfc38c44348b0780b8fe8"
+  integrity sha512-hyGmlt+cZur7ig6AtAFLLTtWdXAmIE77C7Hitlo2+6krYagW71UaSA6O2W0ErweY7SlNcmqZOrxMSkYbSf6f1Q==
   dependencies:
     "@ipld/car" "^5.3.2"
     "@ipld/unixfs" "^3.0.0"
-    "@webrecorder/wabac" "^2.20.0"
+    "@webrecorder/wabac" "^2.20.4"
     auto-js-ipfs "^2.3.0"
     client-zip "^2.3.0"
     hash-wasm "^4.9.0"
@@ -2284,10 +2319,10 @@
     uuid "^9.0.0"
     warcio "^2.3.1"
 
-"@webrecorder/wabac@^2.20.0", "@webrecorder/wabac@^2.20.3":
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.3.tgz#4e3faa476477b64ba2c2315f57d38372d0acf4c0"
-  integrity sha512-bik2YbIJwox5LctL3QwZ1pvG89ORR31do3mFHTF1l4zcvjqeLoqCHIImEsgl9uH7KYq27UxeG4y25Jo3PxA5qQ==
+"@webrecorder/wabac@^2.20.3", "@webrecorder/wabac@^2.20.4":
+  version "2.20.4"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.20.4.tgz#aacc3038e92992fb58039107fe57dfdb41893542"
+  integrity sha512-OK9nMI03rDL+KEn5iT1TUKuz7AdjzeS3F0/5KTOWHp+QCN3ZvjABRLZYxa9LIGiEWKbVEvoG/oriFZntR3/VWw==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
@@ -2312,7 +2347,7 @@
     path-parser "^6.1.0"
     process "^0.11.10"
     stream-browserify "^3.0.0"
-    warcio "^2.4.0"
+    warcio "^2.4.2"
 
 "@webrecorder/wombat@^3.8.6":
   version "3.8.6"
@@ -4942,9 +4977,9 @@ ignore@^5.2.0:
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
 ignore@^5.2.4:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
-  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 immutable@^4.0.0:
   version "4.3.6"
@@ -5823,6 +5858,13 @@ minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
@@ -8172,6 +8214,20 @@ warcio@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.0.tgz#13bae2837f1bbf5cf7585f75857e6311d30557bd"
   integrity sha512-EfxXCgsnZ35CGf2j99QBMyB6EI98KEQ6YmeER+8Lnv/4KFJ3thT76PiX37HfZVbPJS21JihA0Eddjk9QBQRlPg==
+  dependencies:
+    "@types/pako" "^1.0.7"
+    "@types/stream-buffers" "^3.0.7"
+    base32-encode "^2.0.0"
+    hash-wasm "^4.9.0"
+    pako "^1.0.11"
+    tempy "^3.1.0"
+    uuid-random "^1.3.2"
+    yargs "^17.7.2"
+
+warcio@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.2.tgz#782d8dcb0769f271b0ae96521fb4969e2570e9b3"
+  integrity sha512-QYbZ3EGYtnAIrzL7Bajo7ak87pipilpkIfaFIzFQWUX4wuXNuKqnfQy/EAoi2tEIl3VJgsWcL+wjjk4+15MKbQ==
   dependencies:
     "@types/pako" "^1.0.7"
     "@types/stream-buffers" "^3.0.7"


### PR DESCRIPTION
support for configurable cookie / storage archiving, from UI settings from #276
fix for facebook archiving + replay using dash rewriting + range-from-query replay via wabac.js 2.20.4
fixes #272, #273