### PR TITLE
deps update + make windows installation configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.2",
     "@ipld/unixfs": "^3.0.0",
-    "@webrecorder/wabac": "^2.23.7",
+    "@webrecorder/wabac": "^2.23.9",
     "auto-js-ipfs": "^2.3.0",
     "browsertrix-behaviors": "^0.8.5",
     "btoa": "^1.2.1",
@@ -28,7 +28,7 @@
     "p-queue": "^8.0.1",
     "pdfjs-dist": "2.2.228",
     "pretty-bytes": "^5.6.0",
-    "replaywebpage": "^2.3.15",
+    "replaywebpage": "^2.3.16",
     "stream-browserify": "^3.0.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "unused-filename": "^4.0.1",
@@ -69,7 +69,7 @@
     "webpack-extension-reloader": "^1.1.4"
   },
   "resolutions": {
-    "@webrecorder/wabac": "^2.23.7"
+    "@webrecorder/wabac": "^2.23.9"
   },
   "files": [
     "src/",
@@ -143,10 +143,15 @@
       ]
     },
     "win": {
-      "target": "portable",
+      "target": "nsis",
       "extraResources": [
         "plugins-win"
       ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true
     },
     "directories": {
       "buildResources": "build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/archivewebpage",
   "productName": "ArchiveWeb.page",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "main": "index.js",
   "description": "Create Web Archives directly in your browser",
   "repository": {
@@ -14,7 +14,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.2",
     "@ipld/unixfs": "^3.0.0",
-    "@webrecorder/wabac": "^2.23.2",
+    "@webrecorder/wabac": "^2.23.7",
     "auto-js-ipfs": "^2.3.0",
     "browsertrix-behaviors": "^0.8.5",
     "btoa": "^1.2.1",
@@ -28,7 +28,7 @@
     "p-queue": "^8.0.1",
     "pdfjs-dist": "2.2.228",
     "pretty-bytes": "^5.6.0",
-    "replaywebpage": "^2.3.12",
+    "replaywebpage": "^2.3.15",
     "stream-browserify": "^3.0.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "unused-filename": "^4.0.1",
@@ -69,7 +69,7 @@
     "webpack-extension-reloader": "^1.1.4"
   },
   "resolutions": {
-    "@webrecorder/wabac": "^2.23.2"
+    "@webrecorder/wabac": "^2.23.7"
   },
   "files": [
     "src/",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
       ]
     },
     "win": {
-      "target": "nsis",
+      "target": "portable",
       "extraResources": [
         "plugins-win"
       ]

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1473,7 +1473,7 @@ class Recorder {
     const ct = this._getContentType(params.responseHeaders);
 
     switch (ct) {
-      case "application/x-mpegURL":
+      case "application/x-mpegurl":
       case "application/vnd.apple.mpegurl":
         string = payload.toString("utf-8");
         newString = rewriteHLS(string, { save: reqresp.extraOpts });
@@ -1543,7 +1543,7 @@ class Recorder {
   _getContentType(headers) {
     for (const header of headers) {
       if (header.name.toLowerCase() === "content-type") {
-        return header.value.split(";")[0];
+        return header.value.split(";")[0].toLowerCase();
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,10 +2401,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.23.2":
-  version "2.23.2"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.2.tgz#be6447bffe90d45d4a7fbee894f7a544a4a281e9"
-  integrity sha512-hYtr62PvHqE9FHhzPFwi9prA6bqnbX/SXYB4IcKrCvENgB1EqB71/bEBUqZ4GbMnX2pI4YNJfpA7tXF+n1Azgw==
+"@webrecorder/wabac@^2.23.7":
+  version "2.23.7"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.7.tgz#b8b1fc94774de773ebf927ede7b30855b734773d"
+  integrity sha512-tdWZe+ddg49+H5FSbNytVLHBNsNClTc9fjpbmALdF8usvdRV7JsKyGS8CWsIgBbJxdROfgdx8L0IAhRS5f055A==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
@@ -7499,14 +7499,14 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-replaywebpage@^2.3.12:
-  version "2.3.12"
-  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.12.tgz#49ae35f213f4e71a92ecd8ccc3c453ded87ec985"
-  integrity sha512-ej+hRzwxsoMULWLFGZomB5WQ6Yr1Ax7QULxnF09ih9+lkb3j6OyYQ/hCZ+dvAlLuk0eXFD8r32ThnPmuX+EFMw==
+replaywebpage@^2.3.15:
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.15.tgz#c73a03d96f3bc2ca6b6f03451bfbe0328a6ee71c"
+  integrity sha512-TwdkrIEkoSWGXnCgFolQPbIFukNKpFo0kMM83kL/oIVVYY+Hk8O39xGZW41WTePTHUGvUQOSdPzuidpQv8t0Lg==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.4"
     "@shoelace-style/shoelace" "~2.15.1"
-    "@webrecorder/wabac" "^2.23.2"
+    "@webrecorder/wabac" "^2.23.7"
     bulma "^0.9.3"
     electron-log "^4.4.1"
     electron-updater "^6.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,16 +2401,16 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.23.7":
-  version "2.23.7"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.7.tgz#b8b1fc94774de773ebf927ede7b30855b734773d"
-  integrity sha512-tdWZe+ddg49+H5FSbNytVLHBNsNClTc9fjpbmALdF8usvdRV7JsKyGS8CWsIgBbJxdROfgdx8L0IAhRS5f055A==
+"@webrecorder/wabac@^2.23.9":
+  version "2.23.9"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.9.tgz#23b74dc8404dfcf061888b439db4343e76b9e153"
+  integrity sha512-NUJx6dcnOpCSnhbFq6cAce8Cn3aHkA6HPNKuu14UrLLMWR3q8Of5TNOuX+ET+lf1UgMYS8AcQ/dR3j/CM4YcJw==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
     "@peculiar/x509" "^1.9.2"
     "@types/js-levenshtein" "^1.1.3"
-    "@webrecorder/wombat" "^3.8.13"
+    "@webrecorder/wombat" "^3.8.14"
     acorn "^8.10.0"
     auto-js-ipfs "^2.1.1"
     base64-js "^1.5.1"
@@ -2418,7 +2418,6 @@
     buffer "^6.0.3"
     fast-xml-parser "^4.4.1"
     hash-wasm "^4.9.0"
-    http-link-header "^1.1.3"
     http-status-codes "^2.1.4"
     idb "^7.1.1"
     js-levenshtein "^1.1.6"
@@ -2431,10 +2430,10 @@
     stream-browserify "^3.0.0"
     warcio "^2.4.3"
 
-"@webrecorder/wombat@^3.8.13":
-  version "3.8.13"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.13.tgz#264f639dd102dca415f5d01a649d6b95dfac9779"
-  integrity sha512-gg80bEpJE+2Wn0ZTbfCkt9+vTftJemBwAWe9TYXo7ErCX1v7RbIrZ5LfkjSWx3vCx6R4V31DxXk1mycsVrEapA==
+"@webrecorder/wombat@^3.8.14":
+  version "3.8.14"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.14.tgz#fde951519ed9ab8271107a013fc1abd6a9997424"
+  integrity sha512-1CaL8Oel02V321SS+wOomV+cSDo279eVEAuiamO9jl9YoijRsGL9z/xZKE6sz6npLltE3YYziEBYO81xnaeTcA==
   dependencies:
     warcio "^2.4.0"
 
@@ -5083,11 +5082,6 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-link-header@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/http-link-header/-/http-link-header-1.1.3.tgz#b367b7a0ad1cf14027953f31aa1df40bb433da2a"
-  integrity sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==
-
 http-parser-js@>=0.5.1:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
@@ -7499,14 +7493,14 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-replaywebpage@^2.3.15:
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.15.tgz#c73a03d96f3bc2ca6b6f03451bfbe0328a6ee71c"
-  integrity sha512-TwdkrIEkoSWGXnCgFolQPbIFukNKpFo0kMM83kL/oIVVYY+Hk8O39xGZW41WTePTHUGvUQOSdPzuidpQv8t0Lg==
+replaywebpage@^2.3.16:
+  version "2.3.16"
+  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.16.tgz#dcc2a3f2bc4c06db53d320aecdd6087caf7b6e7a"
+  integrity sha512-ceA1f8GcozDgcYjQYBwV+5Sk1+kroX8ukTpkf5QBv/urQpl50/cEMNL0u39hXxagK+SMZ/U8vXWcqNMyqEztEg==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.4"
     "@shoelace-style/shoelace" "~2.15.1"
-    "@webrecorder/wabac" "^2.23.7"
+    "@webrecorder/wabac" "^2.23.9"
     bulma "^0.9.3"
     electron-log "^4.4.1"
     electron-updater "^6.6.2"


### PR DESCRIPTION
deps: update to wabac.js 2.23.9 + replaywebpage 2.3.16
electron app: make windows installation more configurable: user should be able to choose directory, instead of one-click installation to allow for users that need to install into a different directory than the default
electron app: AppImage issue #308 (via replaywebpage)
bump to 0.15.3