### PR TITLE
deps: update for 0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/archivewebpage",
   "productName": "ArchiveWeb.page",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "main": "index.js",
   "description": "Create Web Archives directly in your browser",
   "repository": {
@@ -14,9 +14,9 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ipld/car": "^5.3.2",
     "@ipld/unixfs": "^3.0.0",
-    "@webrecorder/wabac": "^2.23.9",
+    "@webrecorder/wabac": "^2.23.11",
     "auto-js-ipfs": "^2.3.0",
-    "browsertrix-behaviors": "^0.8.5",
+    "browsertrix-behaviors": "^0.9.2",
     "btoa": "^1.2.1",
     "bulma": "^0.9.3",
     "client-zip": "^2.3.0",
@@ -28,12 +28,12 @@
     "p-queue": "^8.0.1",
     "pdfjs-dist": "2.2.228",
     "pretty-bytes": "^5.6.0",
-    "replaywebpage": "^2.3.16",
+    "replaywebpage": "^2.3.17",
     "stream-browserify": "^3.0.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "unused-filename": "^4.0.1",
     "uuid": "^9.0.0",
-    "warcio": "^2.4.4"
+    "warcio": "^2.4.5"
   },
   "devDependencies": {
     "@types/mime-types": "^3.0.0",
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^6.15.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",
-    "electron": "^36.3.2",
+    "electron": "^36.8.1",
     "electron-builder": "^26.0.12",
     "electron-notarize": "^1.2.2",
     "eslint": "^8.28.0",
@@ -69,7 +69,7 @@
     "webpack-extension-reloader": "^1.1.4"
   },
   "resolutions": {
-    "@webrecorder/wabac": "^2.23.9"
+    "@webrecorder/wabac": "^2.23.11"
   },
   "files": [
     "src/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,10 +2401,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@webrecorder/wabac@^2.23.9":
-  version "2.23.9"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.9.tgz#23b74dc8404dfcf061888b439db4343e76b9e153"
-  integrity sha512-NUJx6dcnOpCSnhbFq6cAce8Cn3aHkA6HPNKuu14UrLLMWR3q8Of5TNOuX+ET+lf1UgMYS8AcQ/dR3j/CM4YcJw==
+"@webrecorder/wabac@^2.23.11":
+  version "2.23.11"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wabac/-/wabac-2.23.11.tgz#945da06e08b6d093b525e6e5bfd6a8f17beb995b"
+  integrity sha512-rsBAkcYvgX+0HgwhgvSb3cBCBp0rVnHGQS/K5A9aJwOmfymHt0C2vInH/lmKV/5H38rJu29c2cvRX962h+lUiw==
   dependencies:
     "@peculiar/asn1-ecc" "^2.3.4"
     "@peculiar/asn1-schema" "^2.3.3"
@@ -2428,7 +2428,7 @@
     path-parser "^6.1.0"
     process "^0.11.10"
     stream-browserify "^3.0.0"
-    warcio "^2.4.3"
+    warcio "^2.4.5"
 
 "@webrecorder/wombat@^3.8.14":
   version "3.8.14"
@@ -2996,10 +2996,10 @@ browserslist@^4.24.0:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.3"
 
-browsertrix-behaviors@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.8.5.tgz#f93dc6fed15cb2266664c85eec7f0796c1634fa5"
-  integrity sha512-v6wv6NLJEhj3NbrmGEfOWyXf2TuJgj95Em+KfCTPRJxakTtsvH/A7n2FSNvqMhwusqrjpIR4ch6cEkDp4hblvQ==
+browsertrix-behaviors@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/browsertrix-behaviors/-/browsertrix-behaviors-0.9.2.tgz#b5bee47d15014a05a873d8cc6ea8917bfa61d5c8"
+  integrity sha512-d7rLNKXaiD83S4uXKBUf2x9UzmMjbrqKoO820KVqzWtlpzqnXFUsqN/wKvMSiNbDzmL1+G9Um7Gwb1AjD0djCw==
   dependencies:
     query-selector-shadow-dom "^1.0.1"
 
@@ -3932,10 +3932,10 @@ electron-updater@^6.6.2:
     semver "^7.6.3"
     tiny-typed-emitter "^2.1.0"
 
-electron@^36.3.2:
-  version "36.3.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-36.3.2.tgz#4a60f95e8d3858d01570c03b58dc2fb2f17ee8b6"
-  integrity sha512-v0/j7n22CL3OYv9BIhq6JJz2+e1HmY9H4bjTk8/WzVT9JwVX/T/21YNdR7xuQ6XDSEo9gP5JnqmjOamE+CUY8Q==
+electron@^36.8.1:
+  version "36.8.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-36.8.1.tgz#c27dfb13fcc1bedf29929fe67430ee13a778c4df"
+  integrity sha512-honaH58/cyCb9QAzIvD+WXWuNIZ0tW9zfBqMz5wZld/rXB+LCTEDb2B3TAv8+pDmlzPlkPio95RkUe86l6MNjg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"
@@ -7493,14 +7493,14 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-replaywebpage@^2.3.16:
-  version "2.3.16"
-  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.16.tgz#dcc2a3f2bc4c06db53d320aecdd6087caf7b6e7a"
-  integrity sha512-ceA1f8GcozDgcYjQYBwV+5Sk1+kroX8ukTpkf5QBv/urQpl50/cEMNL0u39hXxagK+SMZ/U8vXWcqNMyqEztEg==
+replaywebpage@^2.3.17:
+  version "2.3.17"
+  resolved "https://registry.yarnpkg.com/replaywebpage/-/replaywebpage-2.3.17.tgz#21dff8752ab2d1a9fed96d789ae6b7e81c57fe47"
+  integrity sha512-b42PxbZlVnNQc66c7nTbem0Z0E2J/IiMtgn+ddUgPRiqejvansiC0+geMDNNtp1MLF7n9DGcSkhNLsR0dPYihQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.4"
     "@shoelace-style/shoelace" "~2.15.1"
-    "@webrecorder/wabac" "^2.23.9"
+    "@webrecorder/wabac" "^2.23.11"
     bulma "^0.9.3"
     electron-log "^4.4.1"
     electron-updater "^6.6.2"
@@ -8974,24 +8974,10 @@ warcio@^2.4.0:
     uuid-random "^1.3.2"
     yargs "^17.7.2"
 
-warcio@^2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.3.tgz#37ff95c2358d0d5ddb16e924fe200c4774b3903d"
-  integrity sha512-c397HNfLE7yJsyVF3XKXB+Yh3q3WKljhdYRPkKF9eyZMtB+HIxj1aBqgq0nTYz492KMKtzygBo0Gx+Gi0fJ9dg==
-  dependencies:
-    "@types/pako" "^1.0.7"
-    "@types/stream-buffers" "^3.0.7"
-    base32-encode "^2.0.0"
-    hash-wasm "^4.9.0"
-    pako "^1.0.11"
-    tempy "^3.1.0"
-    uuid-random "^1.3.2"
-    yargs "^17.7.2"
-
-warcio@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.4.tgz#6c0c030bb55c0f0b824f854fa9e6718ca25d333d"
-  integrity sha512-FrWOhv1qLNhPBPGEMm24Yo+DtkipK5DxK3ckVGbOf0OJ/UqaxAhiiby74q+GW70dsJV0wF+RA1ToK6CKseTshA==
+warcio@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.5.tgz#ba39c38e433491ab9016282813b9cf6539c3d808"
+  integrity sha512-b6R/aIsR4fXzrpY/Zud7LqHFi2Bt8Ov5VLOnruHQ10rk129e9d0KOCZlyRmPD6ENTcV7yze5rXvJ5WSNS8R1zw==
   dependencies:
     "@types/pako" "^1.0.7"
     "@types/stream-buffers" "^3.0.7"


### PR DESCRIPTION
update: warcio (2.4.5), wabac.js (2.23.11), replaywebpage (2.3.17), browsertrix-behaviors (0.9.2) and electron (36.8.1)
bump to 0.15.4