### PR TITLE
ensure about:blank pages are never recorded!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webrecorder/archivewebpage",
   "productName": "ArchiveWeb.page",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "main": "index.js",
   "description": "Create Web Archives directly in your browser",
   "repository": {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -368,7 +368,7 @@ class Recorder {
       }
 
       // @ts-expect-error - TS2339 - Property '_cachePageInfo' does not exist on type 'Recorder'.
-      if (this._cachePageInfo) {
+      if (!this.isEmptyPage(this._cachePageInfo)) {
         // @ts-expect-error - TS2339 - Property '_doAddPage' does not exist on type 'Recorder'. | TS2339 - Property '_cachePageInfo' does not exist on type 'Recorder'.
         await this._doAddPage(this._cachePageInfo);
         // @ts-expect-error - TS2339 - Property '_cachePageInfo' does not exist on type 'Recorder'.
@@ -1107,10 +1107,9 @@ class Recorder {
 
   // @ts-expect-error - TS7006 - Parameter 'currPage' implicitly has an 'any' type. | TS7006 - Parameter 'domSnapshot' implicitly has an 'any' type. | TS7006 - Parameter 'finished' implicitly has an 'any' type.
   commitPage(currPage, domSnapshot, finished) {
-    if (!currPage?.url || !currPage.ts || currPage.url === "about:blank") {
+    if (this.isEmptyPage(currPage)) {
       return;
     }
-
     if (domSnapshot) {
       currPage.text = this.parseTextFromDOMSnapshot(domSnapshot);
     } else if (!currPage.text) {
@@ -1147,12 +1146,14 @@ class Recorder {
     // @ts-expect-error - TS2339 - Property 'sizeNew' does not exist on type 'Recorder'.
     this.sizeNew += writtenSize;
 
-    // @ts-expect-error - TS2339 - Property '_cachePageInfo' does not exist on type 'Recorder'.
-    this._cachePageInfo = pageInfo;
-    // @ts-expect-error - TS2339 - Property '_cacheSessionTotal' does not exist on type 'Recorder'.
-    this._cacheSessionTotal += payloadSize;
-    // @ts-expect-error - TS2339 - Property '_cacheSessionNew' does not exist on type 'Recorder'.
-    this._cacheSessionNew += writtenSize;
+    if (writtenSize) {
+      // @ts-expect-error - TS2339 - Property '_cachePageInfo' does not exist on type 'Recorder'.
+      this._cachePageInfo = pageInfo;
+      // @ts-expect-error - TS2339 - Property '_cacheSessionTotal' does not exist on type 'Recorder'.
+      this._cacheSessionTotal += payloadSize;
+      // @ts-expect-error - TS2339 - Property '_cacheSessionNew' does not exist on type 'Recorder'.
+      this._cacheSessionNew += writtenSize;
+    }
   }
 
   // @ts-expect-error - TS7006 - Parameter 'params' implicitly has an 'any' type. | TS7006 - Parameter 'sessions' implicitly has an 'any' type.
@@ -1225,6 +1226,14 @@ class Recorder {
     this.updateStatus();
     // @ts-expect-error - TS2339 - Property 'firstPageStarted' does not exist on type 'Recorder'.
     this.firstPageStarted = true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  isEmptyPage(pageInfo: any) {
+    if (!pageInfo?.url || !pageInfo.ts || pageInfo.url === "about:blank") {
+      return true;
+    }
+    return false;
   }
 
   // @ts-expect-error - TS7006 - Parameter 'url' implicitly has an 'any' type. | TS7006 - Parameter 'mime' implicitly has an 'any' type.


### PR DESCRIPTION
- don't cache pageinfo if nothing added, use isEmptyPage() check
- exclude about:blank / no-timestamp pageinfo from being added
- bump to 0.15.9
- fixes #314