### PR TITLE
Implement certificate handling popup logic

### DIFF
--- a/src/electron/cert-popup.ts
+++ b/src/electron/cert-popup.ts
@@ -1,0 +1,219 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import fasLock from "@fortawesome/fontawesome-free/svgs/solid/lock.svg";
+import fasLockOpen from "@fortawesome/fontawesome-free/svgs/solid/lock-open.svg";
+
+@customElement("wr-cert-popup")
+export class CertPopup extends LitElement {
+  @property({ type: Object }) cert: any = null;
+  @property({ type: Boolean }) show = false;
+
+  static styles = css`
+    :host {
+      display: block;
+      position: fixed;
+      top: 50px;
+      left: 10px;
+      z-index: 1000;
+      background: white;
+      border: 1px solid #ccc;
+      box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+      border-radius: 4px;
+      max-width: 400px;
+      font-family: sans-serif;
+      font-size: 14px;
+    }
+
+    .popup-content {
+      padding: 15px;
+      max-height: 500px;
+      overflow-y: auto;
+    }
+
+    .close-btn {
+      position: absolute;
+      top: 5px;
+      right: 5px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 16px;
+      color: #666;
+    }
+
+    h3 {
+      margin-top: 0;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 5px;
+    }
+
+    .field {
+      margin-bottom: 10px;
+    }
+
+    .label {
+      font-weight: bold;
+      display: block;
+      margin-bottom: 2px;
+      font-size: 12px;
+      color: #555;
+    }
+
+    .value {
+      word-break: break-all;
+      font-family: monospace;
+      background: #f5f5f5;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
+
+    .section-title {
+      font-weight: bold;
+      margin-top: 10px;
+      margin-bottom: 5px;
+      color: #333;
+      border-bottom: 1px solid #eee;
+    }
+  `;
+
+  render() {
+    if (!this.show || !this.cert) {
+      return html``;
+    }
+
+    return html`
+      <div class="popup-content">
+        <button class="close-btn" @click="${this.close}">×</button>
+        ${this.renderHeader()}
+        
+        <div class="field">
+          <span class="label">Subject</span>
+          ${this.renderPrincipal(this.getCertPrincipal('subject'))}
+        </div>
+
+        <div class="field">
+          <span class="label">Issuer</span>
+          ${this.renderPrincipal(this.getCertPrincipal('issuer'))}
+        </div>
+
+        <div class="field">
+          <span class="label">Validity</span>
+          <div class="value">Issued: ${this.formatDate(this.getCertData().validStart)}</div>
+          <div class="value">Expires: ${this.formatDate(this.getCertData().validExpiry)}</div>
+        </div>
+
+        <div class="field">
+          <span class="label">Fingerprint (SHA1)</span>
+          <div class="value">${this.getCertData().fingerprint}</div>
+        </div>
+        
+        ${this.getCertData().fingerprint256 ? html`
+        <div class="field">
+          <span class="label">Fingerprint (SHA256)</span>
+          <div class="value">${this.getCertData().fingerprint256}</div>
+        </div>` : ""}
+
+        <div class="field">
+            <span class="label">Serial Number</span>
+            <div class="value">${this.getCertData().serialNumber}</div>
+        </div>
+
+      </div>
+    `;
+  }
+
+  isCertValid() {
+    if (!this.cert) return false;
+
+    // Check Electron's verification result if available
+    if (this.cert.verificationResult && this.cert.verificationResult !== "net::OK") {
+      return false;
+    }
+
+    // Fallback/Double-check dates
+    const now = Date.now() / 1000;
+    if (this.cert.certificate) {
+      // Handle wrapped object structure if verificationResult is present
+      const innerCert = this.cert.certificate;
+      return now >= innerCert.validStart && now <= innerCert.validExpiry;
+    }
+
+    // Direct cert object (backward compatibility or if verificationResult missing)
+    return now >= this.cert.validStart && now <= this.cert.validExpiry;
+  }
+
+  getCertPrincipal(type: 'subject' | 'issuer') {
+    if (this.cert.certificate) {
+      return this.cert.certificate[type];
+    }
+    return this.cert[type];
+  }
+
+  getCertData() {
+    return this.cert.certificate || this.cert;
+  }
+
+  renderHeader() {
+    const isValid = this.isCertValid();
+    const icon = isValid ? fasLock : fasLockOpen;
+    const color = isValid ? "#2ea44f" : "#cb2431"; // GitHub Green / Red
+    const text = isValid ? "Valid Certificate" : "Invalid Certificate";
+
+    return html`
+        <div style="display: flex; align-items: center; border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 10px;">
+            <span style="color: ${color}; margin-right: 10px; width: 24px; height: 24px; display: inline-block;">
+                <fa-icon .svg="${icon}" size="1.5em"></fa-icon>
+            </span>
+            <div>
+                <h3 style="margin: 0; padding: 0; border: none;">Certificate Details</h3>
+                <span style="color: ${color}; font-weight: bold; font-size: 12px;">${text}</span>
+            </div>
+        </div>
+    `;
+  }
+
+  renderPrincipal(principal: any) {
+    if (!principal) return html`<div class="value">N/A</div>`;
+
+    // Common fields to display first
+    const priorityKeys = ['commonName', 'organizationName', 'organizationalUnitName', 'countryName'];
+
+    // Helper to map keys to readable labels
+    const labels: Record<string, string> = {
+      commonName: 'CN',
+      organizations: 'Org',
+      organizationUnits: 'OU',
+      locality: 'L',
+      state: 'ST',
+      country: 'C'
+    };
+
+    return html`
+            <div style="background: #f9f9f9; padding: 5px; border-radius: 4px; border: 1px solid #eee;">
+                ${Object.entries(principal).map(([k, v]) => {
+      // specific filtering or ordering could go here
+      const label = labels[k] || k;
+      // Handle arrays (organizations/units are often arrays)
+      const value = Array.isArray(v) ? v.join(", ") : v;
+
+      return html`<div style="display: flex; margin-bottom: 2px; align-items: baseline;">
+                        <span style="font-weight: bold; min-width: 60px; width: 60px; color: #666; font-size: 11px; margin-right: 5px;">${label}:</span>
+                        <span style="flex: 1; word-break: break-all; font-family: monospace; font-size: 12px;">${value}</span>
+                     </div>`;
+    })}
+            </div>
+        `;
+  }
+
+  formatDate(seconds: number) {
+    if (!seconds) return "Invalid Date";
+    return new Date(seconds * 1000).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'medium'
+    });
+  }
+
+  close() {
+    this.dispatchEvent(new CustomEvent("close"));
+  }
+}

--- a/src/electron/electron-rec-main.ts
+++ b/src/electron/electron-rec-main.ts
@@ -13,4 +13,4 @@ const recorderApp = new ElectronRecorderApp({
   profileName: process.env.AWP_PROFILE_NAME || "archivewebpage",
 });
 
-recorderApp.init();
+//recorderApp.init();

--- a/src/electron/rec-preload.ts
+++ b/src/electron/rec-preload.ts
@@ -11,4 +11,8 @@ contextBridge.exposeInMainWorld("archivewebpage", {
   sendMsg: (id, msg) => {
     ipcRenderer.send("popup-msg-" + id, msg);
   },
+  // @ts-expect-error - TS7006 - Parameter 'id' implicitly has an 'any' type.
+  getCertificate: (id) => {
+    return ipcRenderer.invoke("get-certificate", id);
+  },
 });

--- a/src/electron/rec-window.ts
+++ b/src/electron/rec-window.ts
@@ -17,7 +17,9 @@ import fasRight from "@fortawesome/fontawesome-free/svgs/solid/arrow-right.svg";
 import awpLogo from "../assets/brand/archivewebpage-icon-color.svg";
 
 import "./app-popup";
+import "./cert-popup";
 import { BEHAVIOR_RUNNING } from "../consts";
+import fasLock from "@fortawesome/fontawesome-free/svgs/solid/lock.svg";
 
 class RecWindowUI extends LitElement {
   constructor() {
@@ -38,6 +40,10 @@ class RecWindowUI extends LitElement {
 
     // @ts-expect-error - TS2339 - Property 'showPopup' does not exist on type 'RecWindowUI'.
     this.showPopup = false;
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    this.showCertPopup = false;
+    // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+    this.certData = null;
 
     this.initStats();
   }
@@ -77,6 +83,8 @@ class RecWindowUI extends LitElement {
       autorun: { type: Boolean },
 
       showPopup: { type: Boolean },
+      showCertPopup: { type: Boolean },
+      certData: { type: Object },
       wcId: { type: Number },
     };
   }
@@ -140,6 +148,55 @@ class RecWindowUI extends LitElement {
         margin: 0px 8px;
       }
 
+      .icons-left-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        padding-left: 8px;
+        pointer-events: none; /* Let clicks pass through, but re-enable for children */
+        z-index: 4;
+      }
+
+      .icons-left-container > * {
+        pointer-events: auto;
+        margin-right: 4px;
+        position: relative !important;
+        height: auto !important;
+        width: auto !important;
+        top: auto !important;
+        left: auto !important;
+      }
+
+      /* Override Bulma's padding if needed, assuming default is 2.5em (~40px) */
+      .control.has-icons-left .input {
+        padding-left: 4.5em !important; /* Make room for two icons */
+      }
+      
+      .icons-left-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        padding-left: 8px;
+        pointer-events: none; /* Let clicks pass through, but re-enable for children */
+        z-index: 4;
+      }
+      
+      .icons-left-container > * {
+        pointer-events: auto;
+        margin-right: 4px;
+      }
+
+      /* Override Bulma's padding if needed, assuming default is 2.5em (~40px) */
+      .control.has-icons-left .input {
+        padding-left: 4.5em !important; /* Make room for two icons */
+      }
+
       .grey-disabled {
         --fa-icon-fill-color: lightgrey;
         color: lightgrey;
@@ -199,9 +256,9 @@ class RecWindowUI extends LitElement {
               <fa-icon
                 size="1.0em"
                 class="${
-                  // @ts-expect-error - TS2551 - Property 'canGoBack' does not exist on type 'RecWindowUI'. Did you mean 'onGoBack'?
-                  this.canGoBack ? "" : "grey-disabled"
-                }"
+      // @ts-expect-error - TS2551 - Property 'canGoBack' does not exist on type 'RecWindowUI'. Did you mean 'onGoBack'?
+      this.canGoBack ? "" : "grey-disabled"
+      }"
                 aria-hidden="true"
                 .svg="${fasLeft}"
               ></fa-icon>
@@ -220,9 +277,9 @@ class RecWindowUI extends LitElement {
               <fa-icon
                 size="1.0em"
                 class="${
-                  // @ts-expect-error - TS2551 - Property 'canGoForward' does not exist on type 'RecWindowUI'. Did you mean 'onGoForward'?
-                  this.canGoForward ? "" : "grey-disabled"
-                }"
+      // @ts-expect-error - TS2551 - Property 'canGoForward' does not exist on type 'RecWindowUI'. Did you mean 'onGoForward'?
+      this.canGoForward ? "" : "grey-disabled"
+      }"
                 aria-hidden="true"
                 .svg="${fasRight}"
               ></fa-icon>
@@ -233,9 +290,9 @@ class RecWindowUI extends LitElement {
             role="button"
             id="refresh"
             class="button is-borderless ${
-              // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-              this.isLoading ? "is-loading" : ""
-            }"
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      this.isLoading ? "is-loading" : ""
+      }"
             @click="${this.onRefresh}"
             @keyup="${clickOnSpacebarPress}"
             title="Reload"
@@ -243,9 +300,9 @@ class RecWindowUI extends LitElement {
           >
             <span class="icon is-small">
               ${
-                // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-                !this.isLoading
-                  ? html`
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      !this.isLoading
+        ? html`
                       <fa-icon
                         size="1.0em"
                         class="has-text-grey"
@@ -253,44 +310,61 @@ class RecWindowUI extends LitElement {
                         .svg="${fasRefresh}"
                       ></fa-icon>
                     `
-                  : ""
-              }
+        : ""
+      }
             </span>
           </a>
           <form @submit="${this.onSubmit}">
             <div
               class="control is-expanded ${
-                // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                this.favIconUrl ? "has-icons-left" : "has-icons-left"
-              }"
+      // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+      this.favIconUrl ? "has-icons-left" : "has-icons-left"
+      }"
             >
               <input
                 id="url"
                 class="input"
+                style="padding-left: 5em !important;"
                 type="url"
                 @keydown="${this.onKeyDown}"
                 @blur="${this.onLostFocus}"
                 .value="${
-                  // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
-                  this.url
-                }"
+      // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
+      this.url
+      }"
                 placeholder="Enter text to search or a URL to replay"
               />
+              <div class="icons-left-container">
 
               ${
-                // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                this.favIconUrl
-                  ? html` <span class="favicon icon is-small is-left">
+      // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
+      this.url && this.url.startsWith("https://")
+        ? html`<span 
+                      class="icon is-small" 
+                      style="pointer-events: auto; cursor: pointer; z-index: 5;"
+                      @click="${this.onToggleCertPopup}"
+                      title="View Certificate"
+                    >
+                      <fa-icon .svg="${fasLock}" size="0.8em"></fa-icon>
+                    </span>`
+        : ""
+      }
+
+              ${
+      // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+      this.favIconUrl
+        ? html` <span class="favicon icon is-small">
                       <img
                         src="${
-                          // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                          this.favIconUrl
-                        }"
+          // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+          this.favIconUrl
+          }"
                         @error="${this.tryNextIcon}"
                       />
                     </span>`
-                  : html``
-              }
+        : html``
+      }
+              </div>
             </div>
           </form>
           <a
@@ -307,29 +381,29 @@ class RecWindowUI extends LitElement {
                 aria-hidden="true"
               ></fa-icon>
               ${
-                // @ts-expect-error - TS2339 - Property 'recording' does not exist on type 'RecWindowUI'.
-                this.recording
-                  ? // @ts-expect-error - TS2339 - Property 'autorun' does not exist on type 'RecWindowUI'.
-                    html` ${this.autorun
-                      ? html`<span class="overlay overlay-auto"></span>`
-                      : // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
-                        !this.numPending
-                        ? html` <span class="overlay overlay-idle">✓</span>`
-                        : html`
+      // @ts-expect-error - TS2339 - Property 'recording' does not exist on type 'RecWindowUI'.
+      this.recording
+        ? // @ts-expect-error - TS2339 - Property 'autorun' does not exist on type 'RecWindowUI'.
+        html` ${this.autorun
+          ? html`<span class="overlay overlay-auto"></span>`
+          : // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
+          !this.numPending
+            ? html` <span class="overlay overlay-idle">✓</span>`
+            : html`
                             <span class="overlay overlay-waiting"
                               >${
-                                // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
-                                this.numPending
-                              }</span
+              // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
+              this.numPending
+              }</span
                             >
                           `}`
-                  : ""
-              }
+        : ""
+      }
             </span>
           </a>
         </div>
       </nav>
-      ${this.renderWebView()} ${this.renderPopup()}
+      ${this.renderWebView()} ${this.renderPopup()} ${this.renderCertPopup()}
     `;
   }
 
@@ -338,12 +412,12 @@ class RecWindowUI extends LitElement {
       allowpopups=""
       partition="persist:wr"
       @did-start-loading="${
-        // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-        () => (this.isLoading = true)
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      () => (this.isLoading = true)
       }"
       @did-stop-loading="${
-        // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-        () => (this.isLoading = false)
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      () => (this.isLoading = false)
       }"
       @page-favicon-updated="${this.onFaviconUpdated}"
       @will-navigate="${this.onWillNavigate}"
@@ -363,13 +437,56 @@ class RecWindowUI extends LitElement {
     return html`
       <wr-app-popup
         .msg="${
-          // @ts-expect-error - TS2339 - Property 'stats' does not exist on type 'RecWindowUI'.
-          this.stats
-        }"
+      // @ts-expect-error - TS2339 - Property 'stats' does not exist on type 'RecWindowUI'.
+      this.stats
+      }"
         @send-msg="${this.onSendMsg}"
       >
       </wr-app-popup>
     `;
+  }
+
+  renderCertPopup() {
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    if (!this.showCertPopup) {
+      return html``;
+    }
+    return html`
+      <wr-cert-popup
+        .cert="${
+      // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+      this.certData
+      }"
+        .show="${true}"
+        @close="${() =>
+        // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+        (this.showCertPopup = false)}"
+      ></wr-cert-popup>
+    `;
+  }
+
+  async onToggleCertPopup() {
+    console.log("Toggling cert popup");
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    this.showCertPopup = !this.showCertPopup;
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    if (this.showCertPopup) {
+      const webview = this.renderRoot.querySelector("webview");
+      if (webview) {
+        try {
+          // @ts-expect-error - TS2339 - Property 'getWebContentsId' does not exist on type 'Element'.
+          const id = webview.getWebContentsId();
+          console.log("Requesting cert for WC ID:", id);
+          // @ts-expect-error - TS2339 - Property 'archivewebpage' does not exist on type 'Window & typeof globalThis'.
+          const cert = await window.archivewebpage.getCertificate(id);
+          console.log("Cert data received:", cert);
+          // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+          this.certData = cert;
+        } catch (e) {
+          console.error("Error getting cert:", e);
+        }
+      }
+    }
   }
 
   // @ts-expect-error - TS7006 - Parameter 'event' implicitly has an 'any' type.


### PR DESCRIPTION
### Changes
I added a new **lock icon** next to the favicon in the address bar. Clicking this icon now opens a popup displaying the full SSL certificate details of the current page.

### Motivation
This feature is particularly useful for users who perform **screen recordings** during their archiving sessions. It allows them to visually inspect and record the certificate's validity in real-time, providing an extra layer of verification/proof within the video capture itself.