### PR TITLE
Enhance certificate/hash visibility, fix window crash, and expand CLI options

### DIFF
--- a/src/electron/cert-popup.ts
+++ b/src/electron/cert-popup.ts
@@ -1,0 +1,219 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import fasLock from "@fortawesome/fontawesome-free/svgs/solid/lock.svg";
+import fasLockOpen from "@fortawesome/fontawesome-free/svgs/solid/lock-open.svg";
+
+@customElement("wr-cert-popup")
+export class CertPopup extends LitElement {
+  @property({ type: Object }) cert: any = null;
+  @property({ type: Boolean }) show = false;
+
+  static styles = css`
+    :host {
+      display: block;
+      position: fixed;
+      top: 50px;
+      left: 10px;
+      z-index: 1000;
+      background: white;
+      border: 1px solid #ccc;
+      box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+      border-radius: 4px;
+      max-width: 400px;
+      font-family: sans-serif;
+      font-size: 14px;
+    }
+
+    .popup-content {
+      padding: 15px;
+      max-height: 500px;
+      overflow-y: auto;
+    }
+
+    .close-btn {
+      position: absolute;
+      top: 5px;
+      right: 5px;
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 16px;
+      color: #666;
+    }
+
+    h3 {
+      margin-top: 0;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 5px;
+    }
+
+    .field {
+      margin-bottom: 10px;
+    }
+
+    .label {
+      font-weight: bold;
+      display: block;
+      margin-bottom: 2px;
+      font-size: 12px;
+      color: #555;
+    }
+
+    .value {
+      word-break: break-all;
+      font-family: monospace;
+      background: #f5f5f5;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
+
+    .section-title {
+      font-weight: bold;
+      margin-top: 10px;
+      margin-bottom: 5px;
+      color: #333;
+      border-bottom: 1px solid #eee;
+    }
+  `;
+
+  render() {
+    if (!this.show || !this.cert) {
+      return html``;
+    }
+
+    return html`
+      <div class="popup-content">
+        <button class="close-btn" @click="${this.close}">×</button>
+        ${this.renderHeader()}
+        
+        <div class="field">
+          <span class="label">Subject</span>
+          ${this.renderPrincipal(this.getCertPrincipal('subject'))}
+        </div>
+
+        <div class="field">
+          <span class="label">Issuer</span>
+          ${this.renderPrincipal(this.getCertPrincipal('issuer'))}
+        </div>
+
+        <div class="field">
+          <span class="label">Validity</span>
+          <div class="value">Issued: ${this.formatDate(this.getCertData().validStart)}</div>
+          <div class="value">Expires: ${this.formatDate(this.getCertData().validExpiry)}</div>
+        </div>
+
+        <div class="field">
+          <span class="label">Fingerprint (SHA1)</span>
+          <div class="value">${this.getCertData().fingerprint}</div>
+        </div>
+        
+        ${this.getCertData().fingerprint256 ? html`
+        <div class="field">
+          <span class="label">Fingerprint (SHA256)</span>
+          <div class="value">${this.getCertData().fingerprint256}</div>
+        </div>` : ""}
+
+        <div class="field">
+            <span class="label">Serial Number</span>
+            <div class="value">${this.getCertData().serialNumber}</div>
+        </div>
+
+      </div>
+    `;
+  }
+
+  isCertValid() {
+    if (!this.cert) return false;
+
+    // Check Electron's verification result if available
+    if (this.cert.verificationResult && this.cert.verificationResult !== "net::OK") {
+      return false;
+    }
+
+    // Fallback/Double-check dates
+    const now = Date.now() / 1000;
+    if (this.cert.certificate) {
+      // Handle wrapped object structure if verificationResult is present
+      const innerCert = this.cert.certificate;
+      return now >= innerCert.validStart && now <= innerCert.validExpiry;
+    }
+
+    // Direct cert object (backward compatibility or if verificationResult missing)
+    return now >= this.cert.validStart && now <= this.cert.validExpiry;
+  }
+
+  getCertPrincipal(type: 'subject' | 'issuer') {
+    if (this.cert.certificate) {
+      return this.cert.certificate[type];
+    }
+    return this.cert[type];
+  }
+
+  getCertData() {
+    return this.cert.certificate || this.cert;
+  }
+
+  renderHeader() {
+    const isValid = this.isCertValid();
+    const icon = isValid ? fasLock : fasLockOpen;
+    const color = isValid ? "#2ea44f" : "#cb2431"; // GitHub Green / Red
+    const text = isValid ? "Valid Certificate" : "Invalid Certificate";
+
+    return html`
+        <div style="display: flex; align-items: center; border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 10px;">
+            <span style="color: ${color}; margin-right: 10px; width: 24px; height: 24px; display: inline-block;">
+                <fa-icon .svg="${icon}" size="1.5em"></fa-icon>
+            </span>
+            <div>
+                <h3 style="margin: 0; padding: 0; border: none;">Certificate Details</h3>
+                <span style="color: ${color}; font-weight: bold; font-size: 12px;">${text}</span>
+            </div>
+        </div>
+    `;
+  }
+
+  renderPrincipal(principal: any) {
+    if (!principal) return html`<div class="value">N/A</div>`;
+
+    // Common fields to display first
+    const priorityKeys = ['commonName', 'organizationName', 'organizationalUnitName', 'countryName'];
+
+    // Helper to map keys to readable labels
+    const labels: Record<string, string> = {
+      commonName: 'CN',
+      organizations: 'Org',
+      organizationUnits: 'OU',
+      locality: 'L',
+      state: 'ST',
+      country: 'C'
+    };
+
+    return html`
+            <div style="background: #f9f9f9; padding: 5px; border-radius: 4px; border: 1px solid #eee;">
+                ${Object.entries(principal).map(([k, v]) => {
+      // specific filtering or ordering could go here
+      const label = labels[k] || k;
+      // Handle arrays (organizations/units are often arrays)
+      const value = Array.isArray(v) ? v.join(", ") : v;
+
+      return html`<div style="display: flex; margin-bottom: 2px; align-items: baseline;">
+                        <span style="font-weight: bold; min-width: 60px; width: 60px; color: #666; font-size: 11px; margin-right: 5px;">${label}:</span>
+                        <span style="flex: 1; word-break: break-all; font-family: monospace; font-size: 12px;">${value}</span>
+                     </div>`;
+    })}
+            </div>
+        `;
+  }
+
+  formatDate(seconds: number) {
+    if (!seconds) return "Invalid Date";
+    return new Date(seconds * 1000).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'medium'
+    });
+  }
+
+  close() {
+    this.dispatchEvent(new CustomEvent("close"));
+  }
+}

--- a/src/electron/electron-rec-main.ts
+++ b/src/electron/electron-rec-main.ts
@@ -1,5 +1,6 @@
 /*eslint-env node */
 
+import { app } from "electron";
 import { ElectronRecorderApp } from "./electron-recorder-app";
 import path from "path";
 
@@ -8,6 +9,10 @@ import btoa from "btoa";
 global.btoa = btoa;
 
 // ===========================================================================
+if (process.argv.includes("--disable-cache") || process.argv.includes("--disable-http-cache")) {
+  app.commandLine.appendSwitch("disable-http-cache");
+}
+
 const recorderApp = new ElectronRecorderApp({
   staticPath: path.join(__dirname, "./"),
   profileName: process.env.AWP_PROFILE_NAME || "archivewebpage",

--- a/src/electron/electron-recorder-app.ts
+++ b/src/electron/electron-recorder-app.ts
@@ -310,14 +310,13 @@ class ElectronRecorderApp extends ElectronReplayApp {
     recWebContents.setWindowOpenHandler(
       (details: HandlerDetails): WindowOpenHandlerResponse => {
         const { url } = details;
-        return {
-          action: "allow",
-          outlivesOpener: true,
-          createWindow: () => {
-            const win = this.createRecordWindow({ url, collId, startRec });
-            return win.webContents;
-          },
-        };
+
+        // Asynchronously create our custom recording window
+        setTimeout(() => {
+          this.createRecordWindow({ url, collId, startRec });
+        }, 0);
+
+        return { action: "deny" };
       },
     );
 

--- a/src/electron/electron-recorder-app.ts
+++ b/src/electron/electron-recorder-app.ts
@@ -38,6 +38,27 @@ class ElectronRecorderApp extends ElectronReplayApp {
     // @ts-expect-error - TS2339 - Property 'certCache' does not exist on type 'ElectronRecorderApp'.
     this.certCache = new Map();
     this.opts = opts;
+
+    // @ts-expect-error - TS2339 - Property 'downloadPath' does not exist on type 'ElectronRecorderApp'.
+    this.downloadPath = app.getPath("downloads");
+    // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ElectronRecorderApp'.
+    this.startPage = "";
+
+    for (let i = 0; i < process.argv.length; i++) {
+      if (process.argv[i].startsWith("--download-path=")) {
+        // @ts-expect-error - TS2339 - Property 'downloadPath' does not exist on type 'ElectronRecorderApp'.
+        this.downloadPath = process.argv[i].split("=")[1];
+      } else if (process.argv[i] === "--download-path" && i + 1 < process.argv.length) {
+        // @ts-expect-error - TS2339 - Property 'downloadPath' does not exist on type 'ElectronRecorderApp'.
+        this.downloadPath = process.argv[i + 1];
+      } else if (process.argv[i].startsWith("--start-page=")) {
+        // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ElectronRecorderApp'.
+        this.startPage = process.argv[i].split("=")[1];
+      } else if (process.argv[i] === "--start-page" && i + 1 < process.argv.length) {
+        // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ElectronRecorderApp'.
+        this.startPage = process.argv[i + 1];
+      }
+    }
   }
 
   opts: any;
@@ -106,7 +127,8 @@ class ElectronRecorderApp extends ElectronReplayApp {
       console.log(`will-download: ${origFilename}`);
 
       item.setSavePath(
-        unusedFilenameSync(path.join(app.getPath("downloads"), origFilename)),
+        // @ts-expect-error - TS2339 - Property 'downloadPath' does not exist on type 'ElectronRecorderApp'.
+        unusedFilenameSync(path.join(this.downloadPath, origFilename)),
       );
 
       ipcMain.on("dlcancel:" + origFilename, () => {
@@ -158,7 +180,13 @@ class ElectronRecorderApp extends ElectronReplayApp {
   }
 
   get mainWindowUrl() {
-    return "index.html";
+    let url = "index.html";
+    // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ElectronRecorderApp'.
+    if (this.startPage) {
+      // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ElectronRecorderApp'.
+      url += "?startPage=" + encodeURIComponent(this.startPage);
+    }
+    return url;
   }
 
   // @ts-expect-error - TS7006 - Parameter 'argv' implicitly has an 'any' type.

--- a/src/electron/electron-recorder-app.ts
+++ b/src/electron/electron-recorder-app.ts
@@ -122,7 +122,18 @@ class ElectronRecorderApp extends ElectronReplayApp {
     });
 
     sesh.on("will-download", (event, item, webContents) => {
-      const origFilename = item.getFilename();
+      let origFilename = item.getFilename();
+
+      const urlChain = item.getURLChain() || [];
+      const certUrl = urlChain.find(u => u.includes("cert://"));
+      if (certUrl) {
+         try {
+           const host = new URL(certUrl.substring(certUrl.indexOf("cert://"))).hostname;
+           if (host) {
+             origFilename = `${host}_cert.cer`;
+           }
+         } catch(e) {}
+      }
 
       console.log(`will-download: ${origFilename}`);
 
@@ -351,6 +362,43 @@ class ElectronRecorderApp extends ElectronReplayApp {
     recWebContents.on("destroyed", () => {
       // @ts-expect-error - TS2339 - Property 'recorders' does not exist on type 'ElectronRecorderApp'.
       this.recorders.delete(id);
+    });
+
+    const archivedCerts = new Set();
+    // @ts-expect-error - TS7006 - Parameter 'event' implicitly has an 'any' type.
+    recWebContents.on("did-navigate", (event, navUrl: string) => {
+      try {
+        const hostname = new URL(navUrl).hostname;
+        // @ts-expect-error - TS2339 - Property 'certCache' does not exist on type 'ElectronRecorderApp'.
+        const certObj = this.certCache.get(hostname);
+        if (certObj && certObj.certificate && !archivedCerts.has(hostname)) {
+          archivedCerts.add(hostname);
+          const payload = Buffer.from(certObj.certificate.data, "utf8");
+          const data = {
+            url: `cert://${hostname}/`,
+            ts: Date.now(),
+            method: "GET",
+            status: 200,
+            statusText: "OK",
+            mime: "application/x-x509-ca-cert",
+            reqHeaders: {},
+            respHeaders: {
+              "Content-Type": "application/x-x509-ca-cert",
+              "Content-Length": payload.length.toString(),
+              "Content-Disposition": `attachment; filename="${hostname}_cert.cer"`,
+            },
+            payload: payload,
+            extraOpts: { resource: true },
+          };
+          // @ts-expect-error - TS2339 - Property 'recorders' does not exist on type 'ElectronRecorderApp'.
+          const rec = this.recorders.get(id);
+          if (rec && rec.running && rec.appWC) {
+            rec.appWC.send("add-resource", data, collId);
+          }
+        }
+      } catch (e) {
+        // ignore
+      }
     });
 
     //await recWebContents.loadURL("about:blank");

--- a/src/electron/electron-recorder.ts
+++ b/src/electron/electron-recorder.ts
@@ -81,6 +81,8 @@ class ElectronRecorder extends Recorder {
         this.sizeNew += size;
         // @ts-expect-error - TS2339 - Property '_cacheSessionNew' does not exist on type 'ElectronRecorder'.
         this._cacheSessionNew += size;
+        // @ts-expect-error - TS2339 - Property '_cacheSessionTotal' does not exist on type 'ElectronRecorder'.
+        this._cacheSessionTotal += size;
       }
     });
 

--- a/src/electron/rec-preload.ts
+++ b/src/electron/rec-preload.ts
@@ -11,4 +11,8 @@ contextBridge.exposeInMainWorld("archivewebpage", {
   sendMsg: (id, msg) => {
     ipcRenderer.send("popup-msg-" + id, msg);
   },
+  // @ts-expect-error - TS7006 - Parameter 'id' implicitly has an 'any' type.
+  getCertificate: (id) => {
+    return ipcRenderer.invoke("get-certificate", id);
+  },
 });

--- a/src/electron/rec-window.ts
+++ b/src/electron/rec-window.ts
@@ -17,7 +17,9 @@ import fasRight from "@fortawesome/fontawesome-free/svgs/solid/arrow-right.svg";
 import awpLogo from "../assets/brand/archivewebpage-icon-color.svg";
 
 import "./app-popup";
+import "./cert-popup";
 import { BEHAVIOR_RUNNING } from "../consts";
+import fasLock from "@fortawesome/fontawesome-free/svgs/solid/lock.svg";
 
 class RecWindowUI extends LitElement {
   constructor() {
@@ -38,6 +40,10 @@ class RecWindowUI extends LitElement {
 
     // @ts-expect-error - TS2339 - Property 'showPopup' does not exist on type 'RecWindowUI'.
     this.showPopup = false;
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    this.showCertPopup = false;
+    // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+    this.certData = null;
 
     this.initStats();
   }
@@ -77,6 +83,8 @@ class RecWindowUI extends LitElement {
       autorun: { type: Boolean },
 
       showPopup: { type: Boolean },
+      showCertPopup: { type: Boolean },
+      certData: { type: Object },
       wcId: { type: Number },
     };
   }
@@ -140,6 +148,55 @@ class RecWindowUI extends LitElement {
         margin: 0px 8px;
       }
 
+      .icons-left-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        padding-left: 8px;
+        pointer-events: none; /* Let clicks pass through, but re-enable for children */
+        z-index: 4;
+      }
+
+      .icons-left-container > * {
+        pointer-events: auto;
+        margin-right: 4px;
+        position: relative !important;
+        height: auto !important;
+        width: auto !important;
+        top: auto !important;
+        left: auto !important;
+      }
+
+      /* Override Bulma's padding if needed, assuming default is 2.5em (~40px) */
+      .control.has-icons-left .input {
+        padding-left: 4.5em !important; /* Make room for two icons */
+      }
+      
+      .icons-left-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        padding-left: 8px;
+        pointer-events: none; /* Let clicks pass through, but re-enable for children */
+        z-index: 4;
+      }
+      
+      .icons-left-container > * {
+        pointer-events: auto;
+        margin-right: 4px;
+      }
+
+      /* Override Bulma's padding if needed, assuming default is 2.5em (~40px) */
+      .control.has-icons-left .input {
+        padding-left: 4.5em !important; /* Make room for two icons */
+      }
+
       .grey-disabled {
         --fa-icon-fill-color: lightgrey;
         color: lightgrey;
@@ -199,9 +256,9 @@ class RecWindowUI extends LitElement {
               <fa-icon
                 size="1.0em"
                 class="${
-                  // @ts-expect-error - TS2551 - Property 'canGoBack' does not exist on type 'RecWindowUI'. Did you mean 'onGoBack'?
-                  this.canGoBack ? "" : "grey-disabled"
-                }"
+      // @ts-expect-error - TS2551 - Property 'canGoBack' does not exist on type 'RecWindowUI'. Did you mean 'onGoBack'?
+      this.canGoBack ? "" : "grey-disabled"
+      }"
                 aria-hidden="true"
                 .svg="${fasLeft}"
               ></fa-icon>
@@ -220,9 +277,9 @@ class RecWindowUI extends LitElement {
               <fa-icon
                 size="1.0em"
                 class="${
-                  // @ts-expect-error - TS2551 - Property 'canGoForward' does not exist on type 'RecWindowUI'. Did you mean 'onGoForward'?
-                  this.canGoForward ? "" : "grey-disabled"
-                }"
+      // @ts-expect-error - TS2551 - Property 'canGoForward' does not exist on type 'RecWindowUI'. Did you mean 'onGoForward'?
+      this.canGoForward ? "" : "grey-disabled"
+      }"
                 aria-hidden="true"
                 .svg="${fasRight}"
               ></fa-icon>
@@ -233,9 +290,9 @@ class RecWindowUI extends LitElement {
             role="button"
             id="refresh"
             class="button is-borderless ${
-              // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-              this.isLoading ? "is-loading" : ""
-            }"
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      this.isLoading ? "is-loading" : ""
+      }"
             @click="${this.onRefresh}"
             @keyup="${clickOnSpacebarPress}"
             title="Reload"
@@ -243,9 +300,9 @@ class RecWindowUI extends LitElement {
           >
             <span class="icon is-small">
               ${
-                // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-                !this.isLoading
-                  ? html`
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      !this.isLoading
+        ? html`
                       <fa-icon
                         size="1.0em"
                         class="has-text-grey"
@@ -253,44 +310,61 @@ class RecWindowUI extends LitElement {
                         .svg="${fasRefresh}"
                       ></fa-icon>
                     `
-                  : ""
-              }
+        : ""
+      }
             </span>
           </a>
           <form @submit="${this.onSubmit}">
             <div
               class="control is-expanded ${
-                // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                this.favIconUrl ? "has-icons-left" : "has-icons-left"
-              }"
+      // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+      this.favIconUrl ? "has-icons-left" : "has-icons-left"
+      }"
             >
               <input
                 id="url"
                 class="input"
+                style="padding-left: 5em !important;"
                 type="url"
                 @keydown="${this.onKeyDown}"
                 @blur="${this.onLostFocus}"
                 .value="${
-                  // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
-                  this.url
-                }"
+      // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
+      this.url
+      }"
                 placeholder="Enter text to search or a URL to replay"
               />
+              <div class="icons-left-container">
 
               ${
-                // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                this.favIconUrl
-                  ? html` <span class="favicon icon is-small is-left">
+      // @ts-expect-error - TS2339 - Property 'url' does not exist on type 'RecWindowUI'.
+      this.url && this.url.startsWith("https://")
+        ? html`<span 
+                      class="icon is-small" 
+                      style="pointer-events: auto; cursor: pointer; z-index: 5;"
+                      @click="${this.onToggleCertPopup}"
+                      title="View Certificate"
+                    >
+                      <fa-icon .svg="${fasLock}" size="0.8em"></fa-icon>
+                    </span>`
+        : ""
+      }
+
+              ${
+      // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+      this.favIconUrl
+        ? html` <span class="favicon icon is-small">
                       <img
                         src="${
-                          // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
-                          this.favIconUrl
-                        }"
+          // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
+          this.favIconUrl
+          }"
                         @error="${this.tryNextIcon}"
                       />
                     </span>`
-                  : html``
-              }
+        : html``
+      }
+              </div>
             </div>
           </form>
           <a
@@ -307,29 +381,29 @@ class RecWindowUI extends LitElement {
                 aria-hidden="true"
               ></fa-icon>
               ${
-                // @ts-expect-error - TS2339 - Property 'recording' does not exist on type 'RecWindowUI'.
-                this.recording
-                  ? // @ts-expect-error - TS2339 - Property 'autorun' does not exist on type 'RecWindowUI'.
-                    html` ${this.autorun
-                      ? html`<span class="overlay overlay-auto"></span>`
-                      : // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
-                        !this.numPending
-                        ? html` <span class="overlay overlay-idle">✓</span>`
-                        : html`
+      // @ts-expect-error - TS2339 - Property 'recording' does not exist on type 'RecWindowUI'.
+      this.recording
+        ? // @ts-expect-error - TS2339 - Property 'autorun' does not exist on type 'RecWindowUI'.
+        html` ${this.autorun
+          ? html`<span class="overlay overlay-auto"></span>`
+          : // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
+          !this.numPending
+            ? html` <span class="overlay overlay-idle">✓</span>`
+            : html`
                             <span class="overlay overlay-waiting"
                               >${
-                                // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
-                                this.numPending
-                              }</span
+              // @ts-expect-error - TS2339 - Property 'numPending' does not exist on type 'RecWindowUI'.
+              this.numPending
+              }</span
                             >
                           `}`
-                  : ""
-              }
+        : ""
+      }
             </span>
           </a>
         </div>
       </nav>
-      ${this.renderWebView()} ${this.renderPopup()}
+      ${this.renderWebView()} ${this.renderPopup()} ${this.renderCertPopup()}
     `;
   }
 
@@ -338,12 +412,12 @@ class RecWindowUI extends LitElement {
       allowpopups=""
       partition="persist:wr"
       @did-start-loading="${
-        // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-        () => (this.isLoading = true)
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      () => (this.isLoading = true)
       }"
       @did-stop-loading="${
-        // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-        () => (this.isLoading = false)
+      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
+      () => (this.isLoading = false)
       }"
       @page-favicon-updated="${this.onFaviconUpdated}"
       @will-navigate="${this.onWillNavigate}"
@@ -363,13 +437,56 @@ class RecWindowUI extends LitElement {
     return html`
       <wr-app-popup
         .msg="${
-          // @ts-expect-error - TS2339 - Property 'stats' does not exist on type 'RecWindowUI'.
-          this.stats
-        }"
+      // @ts-expect-error - TS2339 - Property 'stats' does not exist on type 'RecWindowUI'.
+      this.stats
+      }"
         @send-msg="${this.onSendMsg}"
       >
       </wr-app-popup>
     `;
+  }
+
+  renderCertPopup() {
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    if (!this.showCertPopup) {
+      return html``;
+    }
+    return html`
+      <wr-cert-popup
+        .cert="${
+      // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+      this.certData
+      }"
+        .show="${true}"
+        @close="${() =>
+        // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+        (this.showCertPopup = false)}"
+      ></wr-cert-popup>
+    `;
+  }
+
+  async onToggleCertPopup() {
+    console.log("Toggling cert popup");
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    this.showCertPopup = !this.showCertPopup;
+    // @ts-expect-error - TS2339 - Property 'showCertPopup' does not exist on type 'RecWindowUI'.
+    if (this.showCertPopup) {
+      const webview = this.renderRoot.querySelector("webview");
+      if (webview) {
+        try {
+          // @ts-expect-error - TS2339 - Property 'getWebContentsId' does not exist on type 'Element'.
+          const id = webview.getWebContentsId();
+          console.log("Requesting cert for WC ID:", id);
+          // @ts-expect-error - TS2339 - Property 'archivewebpage' does not exist on type 'Window & typeof globalThis'.
+          const cert = await window.archivewebpage.getCertificate(id);
+          console.log("Cert data received:", cert);
+          // @ts-expect-error - TS2339 - Property 'certData' does not exist on type 'RecWindowUI'.
+          this.certData = cert;
+        } catch (e) {
+          console.error("Error getting cert:", e);
+        }
+      }
+    }
   }
 
   // @ts-expect-error - TS7006 - Parameter 'event' implicitly has an 'any' type.

--- a/src/electron/rec-window.ts
+++ b/src/electron/rec-window.ts
@@ -288,30 +288,19 @@ class RecWindowUI extends LitElement {
           <a
             href="#"
             role="button"
-            id="refresh"
-            class="button is-borderless ${
-      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-      this.isLoading ? "is-loading" : ""
-      }"
+            class="button is-borderless"
+            id="wr-refresh"
             @click="${this.onRefresh}"
             @keyup="${clickOnSpacebarPress}"
-            title="Reload"
-            aria-label="Reload"
+            title="Refresh"
+            aria-label="Refresh"
           >
             <span class="icon is-small">
-              ${
-      // @ts-expect-error - TS2339 - Property 'isLoading' does not exist on type 'RecWindowUI'.
-      !this.isLoading
-        ? html`
                       <fa-icon
                         size="1.0em"
-                        class="has-text-grey"
                         aria-hidden="true"
                         .svg="${fasRefresh}"
                       ></fa-icon>
-                    `
-        : ""
-      }
             </span>
           </a>
           <form @submit="${this.onSubmit}">

--- a/src/electron/rec-window.ts
+++ b/src/electron/rec-window.ts
@@ -155,7 +155,7 @@ class RecWindowUI extends LitElement {
         height: 100%;
         display: flex;
         align-items: center;
-        padding-left: 8px;
+        padding-left: 11px;
         pointer-events: none; /* Let clicks pass through, but re-enable for children */
         z-index: 4;
       }
@@ -296,11 +296,11 @@ class RecWindowUI extends LitElement {
             aria-label="Refresh"
           >
             <span class="icon is-small">
-                      <fa-icon
-                        size="1.0em"
-                        aria-hidden="true"
-                        .svg="${fasRefresh}"
-                      ></fa-icon>
+              <fa-icon
+                size="1.0em"
+                aria-hidden="true"
+                .svg="${fasRefresh}"
+              ></fa-icon>
             </span>
           </a>
           <form @submit="${this.onSubmit}">
@@ -313,7 +313,7 @@ class RecWindowUI extends LitElement {
               <input
                 id="url"
                 class="input"
-                style="padding-left: 5em !important;"
+                style="padding-left: 4em !important;"
                 type="url"
                 @keydown="${this.onKeyDown}"
                 @blur="${this.onLostFocus}"
@@ -330,11 +330,11 @@ class RecWindowUI extends LitElement {
       this.url && this.url.startsWith("https://")
         ? html`<span 
                       class="icon is-small" 
-                      style="pointer-events: auto; cursor: pointer; z-index: 5;"
+                      style="pointer-events: auto; cursor: pointer; z-index: 100; margin-top: 3px;"
                       @click="${this.onToggleCertPopup}"
                       title="View Certificate"
                     >
-                      <fa-icon .svg="${fasLock}" size="0.8em"></fa-icon>
+                      <fa-icon .svg="${fasLock}" size="1.3em"></fa-icon>
                     </span>`
         : ""
       }
@@ -342,7 +342,7 @@ class RecWindowUI extends LitElement {
               ${
       // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.
       this.favIconUrl
-        ? html` <span class="favicon icon is-small">
+        ? html` <span class="favicon icon is-small drift" style="left: 4px !important;">
                       <img
                         src="${
           // @ts-expect-error - TS2339 - Property 'favIconUrl' does not exist on type 'RecWindowUI'.

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -189,9 +189,9 @@ class Recorder {
       window.addEventListener("DOMContentLoaded", () => {
         const e = document.createElement("script");
         e.src = "${
-          // @ts-expect-error - TS2339 - Property 'getExternalInjectURL' does not exist on type 'Recorder'.
-          this.getExternalInjectURL(path)
-        }";
+      // @ts-expect-error - TS2339 - Property 'getExternalInjectURL' does not exist on type 'Recorder'.
+      this.getExternalInjectURL(path)
+      }";
         document.head.appendChild(e);
       });
     })();
@@ -205,7 +205,7 @@ class Recorder {
     self.__bx_behaviors.init(${
       // @ts-expect-error - TS2339 - Property 'behaviorInitStr' does not exist on type 'Recorder'.
       this.behaviorInitStr
-    });
+      });
 
     window.addEventListener("beforeunload", () => {});\n` +
       (this.archiveFlash ? this.getFlashInjectScript() : "") +
@@ -729,11 +729,11 @@ class Recorder {
           if (allowAttach) {
             console.log(
               "Target Attached: " +
-                type +
-                " " +
-                params.targetInfo.url +
-                " " +
-                params.sessionId,
+              type +
+              " " +
+              params.targetInfo.url +
+              " " +
+              params.sessionId,
             );
 
             if (type === "page" || type === "iframe") {
@@ -742,11 +742,11 @@ class Recorder {
           } else {
             console.log(
               "Not allowed attach for: " +
-                type +
-                " " +
-                params.targetInfo.url +
-                " " +
-                params.sessionId,
+              type +
+              " " +
+              params.targetInfo.url +
+              " " +
+              params.sessionId,
             );
 
             // @ts-expect-error - TS2339 - Property 'flatMode' does not exist on type 'Recorder'.
@@ -764,9 +764,9 @@ class Recorder {
           console.log(e);
           console.warn(
             "Error attaching target: " +
-              params.targetInfo.type +
-              " " +
-              params.targetInfo.url,
+            params.targetInfo.type +
+            " " +
+            params.targetInfo.url,
           );
         }
         break;
@@ -892,6 +892,11 @@ class Recorder {
         }
         break;
 
+      case "Target.attachedToTarget":
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        await this.handleAttachedToTarget(params);
+        break;
+
       default:
         //if (method.startsWith("Target.")) {
         //  console.log(method, params);
@@ -900,6 +905,31 @@ class Recorder {
     }
 
     return true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async handleAttachedToTarget(params: any) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const sessionId = params.sessionId;
+
+    try {
+      await this.send(
+        "Network.setCacheDisabled",
+        // @ts-expect-error - TS2345
+        { cacheDisabled: true },
+        [sessionId]
+      );
+
+      await this.send(
+        "Network.setBypassServiceWorker",
+        // @ts-expect-error - TS2345
+        { bypass: true },
+        [sessionId]
+      );
+
+    } catch (e) {
+      console.log("Error disabling cache on new target", e);
+    }
   }
 
   // @ts-expect-error - TS7006 - Parameter 'url' implicitly has an 'any' type. | TS7006 - Parameter 'sessions' implicitly has an 'any' type.
@@ -928,10 +958,10 @@ class Recorder {
       extractPDF("${
         // @ts-expect-error - TS2339 - Property 'pdfLoadURL' does not exist on type 'Recorder'.
         this.pdfLoadURL
-      }", "${
+        }", "${
         // @ts-expect-error - TS2339 - Property 'getExternalInjectURL' does not exist on type 'Recorder'.
         this.getExternalInjectURL("")
-      }");
+        }");
       `,
       );
 
@@ -999,7 +1029,8 @@ class Recorder {
     const resp = await this.send("Page.captureScreenshot", { format: "png" });
 
     const payload = Buffer.from(resp.data, "base64");
-    const blob = new Blob([payload], { type: "image/png" });
+    //const blob = new Blob([payload], { type: "image/png" });
+    const blob = new Blob([new Uint8Array(payload)], { type: "image/png" });
 
     await this.send("Emulation.clearDeviceMetricsOverride");
 
@@ -2052,13 +2083,13 @@ class Recorder {
       } catch (e) {
         console.warn(
           "no buffer for: " +
-            reqresp.url +
-            " " +
-            reqresp.status +
-            " " +
-            reqresp.requestId +
-            " " +
-            method,
+          reqresp.url +
+          " " +
+          reqresp.status +
+          " " +
+          reqresp.requestId +
+          " " +
+          method,
         );
         console.warn(e);
         return null;

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -7,6 +7,9 @@ import { SWManager } from "replaywebpage";
 
 import fasHelp from "@fortawesome/fontawesome-free/svgs/solid/question-circle.svg";
 import fasPlus from "@fortawesome/fontawesome-free/svgs/solid/plus.svg";
+import fasSyncAlt from "@fortawesome/fontawesome-free/svgs/solid/sync-alt.svg";
+import fasArrowLeft from "@fortawesome/fontawesome-free/svgs/solid/arrow-left.svg";
+import fasArrowRight from "@fortawesome/fontawesome-free/svgs/solid/arrow-right.svg";
 
 import fasUpload from "@fortawesome/fontawesome-free/svgs/solid/upload.svg";
 import fasCog from "@fortawesome/fontawesome-free/svgs/solid/cog.svg";
@@ -483,6 +486,126 @@ class ArchiveWebApp extends ReplayWebApp {
       height="1.25rem"
       aria-hidden="true"
     ></fa-icon>`;
+  }
+
+  renderNavBar() {
+    return html` <a
+        href="#skip-main-target"
+        @click=${this.skipMenu}
+        class="skip-link"
+        >Skip main navigation</a
+      >
+      <nav class="navbar" aria-label="main">
+        <div class="navbar-brand">
+          ${!this.embed
+        ? html`
+                <a
+                  href="${this.homeUrl}"
+                  class="navbar-item wr-logo-item"
+                  aria-label="ReplayWeb.page Home"
+                >
+                  ${this.renderNavBrand()}
+                </a>
+                ${this.collTitle
+            ? html`
+                      <a
+                        href="${this.collPageUrl}"
+                        class="no-wrap is-size-6 has-text-black"
+                        >/&nbsp;&nbsp;<i>${this.collTitle}</i></a
+                      >
+                      <span class="no-wrap is-size-6"
+                        >&nbsp;&nbsp;/&nbsp;
+                        ${this.pageReplay
+                ? html`<i>${this.pageTitle}</i>`
+                : this.pageTitle}
+                      </span>
+                    `
+            : ""}
+              `
+        : html`
+                <span class="navbar-item wr-logo-item">
+                  <fa-icon
+                    id="wrlogo"
+                    size="1.0rem"
+                    .svg=${this.mainLogo}
+                    aria-hidden="true"
+                  ></fa-icon>
+                </span>
+              `}
+          <a
+            href="#"
+            role="button"
+            id="menu-button"
+            @click="${this.onNavMenu}"
+            class="navbar-burger burger ${this.navMenuShown ? "is-active" : ""}"
+            aria-label="main menu"
+            aria-haspopup="true"
+            aria-expanded="${this.navMenuShown}"
+          >
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+          </a>
+        </div>
+        ${!this.sourceUrl
+        ? html` <div
+              class="navbar-menu ${this.navMenuShown ? "is-active" : ""}"
+            >
+              <div class="navbar-start">
+                ${IS_APP
+            ? html`
+                      <a
+                        role="button"
+                        href="#"
+                        class="navbar-item arrow-button"
+                        title="Go Back"
+                        @click="${() => window.history.back()}"
+                      >
+                        <fa-icon
+                          size="1.0rem"
+                          .svg="${fasArrowLeft}"
+                          aria-hidden="true"
+                        ></fa-icon
+                        ><span class="menu-only is-size-7">&nbsp;Go Back</span>
+                      </a>
+                      <a
+                        role="button"
+                        href="#"
+                        class="navbar-item arrow-button"
+                        title="Go Forward"
+                        @click="${() => window.history.forward()}"
+                      >
+                        <fa-icon
+                          size="1.0rem"
+                          .svg="${fasArrowRight}"
+                          aria-hidden="true"
+                        ></fa-icon
+                        ><span class="menu-only is-size-7">&nbsp;Go Forward</span>
+                      </a>
+                      <a
+                        role="button"
+                        href="#"
+                        class="navbar-item arrow-button"
+                        title="Refresh"
+                        @click="${() => window.location.reload()}"
+                      >
+                        <fa-icon
+                          size="1.0rem"
+                          .svg="${fasSyncAlt}"
+                          aria-hidden="true"
+                        ></fa-icon
+                        ><span class="menu-only is-size-7">&nbsp;Refresh</span>
+                      </a>
+                    `
+            : ""}
+              </div>
+              ${!this.embed
+            ? html` <div class="navbar-end">${this.renderNavEnd()}</div>`
+            : html``}
+            </div>`
+        : html``}
+      </nav>
+      <p id="skip-main-target" tabindex="-1" class="is-sr-only">Skipped</p>`;
   }
 
   renderHomeIndex() {

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -171,6 +171,7 @@ class ArchiveWebApp extends ReplayWebApp {
       selCollId: { type: String },
       selCollTitle: { type: String },
       recordUrl: { type: String },
+      startPage: { type: String },
       autorun: { type: Boolean },
 
       showNew: { type: String },
@@ -197,6 +198,8 @@ class ArchiveWebApp extends ReplayWebApp {
 
   initRoute() {
     const pageParams = new URLSearchParams(window.location.search);
+    // @ts-expect-error - TS2339 - Property 'startPage' does not exist on type 'ArchiveWebApp'.
+    this.startPage = pageParams.get("startPage") || "https://example.com/";
 
     if (pageParams.has("config")) {
       super.initRoute();
@@ -236,8 +239,8 @@ class ArchiveWebApp extends ReplayWebApp {
         .register()
         .catch(
           () =>
-            (this.swErrorMsg =
-              this.swmanager?.renderErrorReport(this.mainLogo) || ""),
+          (this.swErrorMsg =
+            this.swmanager?.renderErrorReport(this.mainLogo) || ""),
         );
     }
   }
@@ -461,12 +464,12 @@ class ArchiveWebApp extends ReplayWebApp {
       <a
         href="?about"
         @click="${
-          // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
-          (e) => {
-            e.preventDefault();
-            this.showAbout = true;
-          }
-        }"
+      // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
+      (e) => {
+        e.preventDefault();
+        this.showAbout = true;
+      }
+      }"
         class="navbar-item is-size-6"
         >About
       </a>`;
@@ -492,9 +495,9 @@ class ArchiveWebApp extends ReplayWebApp {
                 class="button is-small no-pad-mobile"
                 title="New Archiving Session"
                 @click="${
-                  // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
-                  () => (this.showNew = "show")
-                }"
+      // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
+      () => (this.showNew = "show")
+      }"
               >
                 <span class="icon">
                   <fa-icon .svg=${fasPlus}></fa-icon>
@@ -552,9 +555,9 @@ class ArchiveWebApp extends ReplayWebApp {
         @colls-updated=${this.onCollsLoaded}
         @ipfs-share-failed=${() => (this.showIpfsShareFailed = true)}
         @do-upload=${
-          // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
-          (e) => (this.uploadCollOpts = e.detail)
-        }
+      // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
+      (e) => (this.uploadCollOpts = e.detail)
+      }
         style="overflow: visible"
       >
       </wr-rec-coll-index>
@@ -567,20 +570,20 @@ class ArchiveWebApp extends ReplayWebApp {
     ${
       // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
       this.showNew ? this.renderNewCollModal() : ""
-    }
+      }
     ${this.showImport ? this.renderImportModal() : ""}
     ${
       // @ts-expect-error - TS2551 - Property 'showDownloadProgress' does not exist on type 'ArchiveWebApp'. Did you mean 'onDownloadProgress'? | TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
       this.showDownloadProgress && this.download
         ? this.renderDownloadModal()
         : ""
-    }
+      }
     ${this.showSettings ? this.renderSettingsModal() : ""}
     ${this.showIpfsShareFailed ? this.renderIPFSShareFailedModal() : ""}
     ${
       // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'. | TS2339 - Property 'btrixOpts' does not exist on type 'ArchiveWebApp'.
       this.uploadCollOpts && this.btrixOpts ? this.renderBtrixUploadModal() : ""
-    }
+      }
     ${super.render()}`;
   }
 
@@ -592,8 +595,8 @@ class ArchiveWebApp extends ReplayWebApp {
       .loadInfo="${this.getLoadInfo(this.sourceUrl || "")}"
       .appLogo="${this.mainLogo}"
       .autoUpdateInterval=${
-        // @ts-expect-error - TS2339 - Property 'embed' does not exist on type 'ArchiveWebApp'. | TS2551 - Property 'showDownloadProgress' does not exist on type 'ArchiveWebApp'. Did you mean 'onDownloadProgress'?
-        this.embed || this.showDownloadProgress ? 0 : 10
+      // @ts-expect-error - TS2339 - Property 'embed' does not exist on type 'ArchiveWebApp'. | TS2551 - Property 'showDownloadProgress' does not exist on type 'ArchiveWebApp'. Did you mean 'onDownloadProgress'?
+      this.embed || this.showDownloadProgress ? 0 : 10
       }
       .shareOpts=${{ ipfsOpts: this.ipfsOpts, btrixOpts: this.btrixOpts }}
       .swName=${this.swName ?? null}
@@ -607,8 +610,8 @@ class ArchiveWebApp extends ReplayWebApp {
       @show-start=${this.onShowStart}
       @show-import=${this.onShowImport}
       @do-upload=${
-        // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
-        (e) => (this.uploadCollOpts = e.detail)
+      // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
+      (e) => (this.uploadCollOpts = e.detail)
       }
       @about-show=${() => (this.showAbout = true)}
     ></wr-rec-coll>`;
@@ -621,17 +624,17 @@ class ArchiveWebApp extends ReplayWebApp {
         <div class="select is-small">
           <select @change="${this.onSelectColl}">
             ${this.colls?.map(
-              (coll) =>
-                html` <option
+      (coll) =>
+        html` <option
                   value="${coll.id}"
                   ?selected="${
-                    // @ts-expect-error - TS2339 - Property 'selCollId' does not exist on type 'ArchiveWebApp'.
-                    this.selCollId === coll.id
-                  }"
+          // @ts-expect-error - TS2339 - Property 'selCollId' does not exist on type 'ArchiveWebApp'.
+          this.selCollId === coll.id
+          }"
                 >
                   ${coll.title || coll.loadUrl}
                 </option>`,
-            )}
+    )}
           </select>
         </div>
       </div>
@@ -641,8 +644,8 @@ class ArchiveWebApp extends ReplayWebApp {
   renderStartModal() {
     return html` <wr-modal
       @modal-closed="${
-        // @ts-expect-error - TS2551 - Property 'showStartRecord' does not exist on type 'ArchiveWebApp'. Did you mean 'onStartRecord'?
-        () => (this.showStartRecord = false)
+      // @ts-expect-error - TS2551 - Property 'showStartRecord' does not exist on type 'ArchiveWebApp'. Did you mean 'onStartRecord'?
+      () => (this.showStartRecord = false)
       }"
       title="Start Archiving"
     >
@@ -653,9 +656,9 @@ class ArchiveWebApp extends ReplayWebApp {
             type="checkbox"
             ?checked="${this.autorun}"
             @change="${
-              // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
-              (e) => (this.autorun = e.currentTarget.checked)
-            }"
+      // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
+      (e) => (this.autorun = e.currentTarget.checked)
+      }"
           />
           Start With Autopilot
         </label>
@@ -674,9 +677,9 @@ class ArchiveWebApp extends ReplayWebApp {
               name="url"
               id="url"
               value="${
-                // @ts-expect-error - TS2339 - Property 'recordUrl' does not exist on type 'ArchiveWebApp'.
-                this.recordUrl
-              }"
+      // @ts-expect-error - TS2339 - Property 'recordUrl' does not exist on type 'ArchiveWebApp'.
+      this.recordUrl
+      }"
               placeholder="Enter a URL to Start Archiving"
             />
           </p>
@@ -697,12 +700,12 @@ class ArchiveWebApp extends ReplayWebApp {
           </div>
         </div>
         ${IS_APP
-          ? html` <label class="checkbox">
+        ? html` <label class="checkbox">
               <input id="preview" type="checkbox" /><span
                 >&nbsp;Start in Preview Mode (without archiving.)</span
               >
             </label>`
-          : ""}
+        : ""}
       </form>
     </wr-modal>`;
   }
@@ -710,8 +713,8 @@ class ArchiveWebApp extends ReplayWebApp {
   renderNewCollModal() {
     return html` <wr-modal
       @modal-closed="${
-        // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
-        () => (this.showNew = null)
+      // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
+      () => (this.showNew = null)
       }"
       title="New Archiving Session"
     >
@@ -731,13 +734,13 @@ class ArchiveWebApp extends ReplayWebApp {
             <button
               type="submit"
               class="button is-hidden-mobile is-primary ${
-                // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
-                this.showNew === "loading" ? "is-loading " : ""
-              }"
+      // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
+      this.showNew === "loading" ? "is-loading " : ""
+      }"
               ?disabled="${
-                // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
-                this.showNew === "loading"
-              }"
+      // @ts-expect-error - TS2339 - Property 'showNew' does not exist on type 'ArchiveWebApp'.
+      this.showNew === "loading"
+      }"
             >
               Create
             </button>
@@ -767,27 +770,27 @@ class ArchiveWebApp extends ReplayWebApp {
               type="checkbox"
               name="add-existing"
               .checked="${
-                // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
-                this.isImportExisting
-              }"
+      // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
+      this.isImportExisting
+      }"
               @change="${
-                // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
-                (e) =>
-                  // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
-                  (this.isImportExisting = e.currentTarget.checked)
-              }"
+      // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
+      (e) =>
+        // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
+        (this.isImportExisting = e.currentTarget.checked)
+      }"
             />
             Add to an existing archived
             item${
-              // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
-              this.isImportExisting ? ":" : ""
-            }
+      // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
+      this.isImportExisting ? ":" : ""
+      }
           </label>
         </div>
         ${
-          // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
-          this.isImportExisting ? this.renderCollList() : ""
-        }
+      // @ts-expect-error - TS2339 - Property 'isImportExisting' does not exist on type 'ArchiveWebApp'.
+      this.isImportExisting ? this.renderCollList() : ""
+      }
       </div>
     </wr-modal>`;
   }
@@ -810,8 +813,8 @@ class ArchiveWebApp extends ReplayWebApp {
     return html` <wr-btrix-upload
       .btrixOpts=${this.btrixOpts}
       .uploadColl=${
-        // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
-        this.uploadCollOpts
+      // @ts-expect-error - TS2339 - Property 'uploadCollOpts' does not exist on type 'ArchiveWebApp'.
+      this.uploadCollOpts
       }
     >
     </wr-btrix-upload>`;
@@ -864,8 +867,8 @@ class ArchiveWebApp extends ReplayWebApp {
       .noBgClose=${true}
       style="--modal-width: 740px"
       @modal-closed="${
-        // @ts-expect-error - TS2551 - Property 'showDownloadProgress' does not exist on type 'ArchiveWebApp'. Did you mean 'onDownloadProgress'?
-        () => (this.showDownloadProgress = false)
+      // @ts-expect-error - TS2551 - Property 'showDownloadProgress' does not exist on type 'ArchiveWebApp'. Did you mean 'onDownloadProgress'?
+      () => (this.showDownloadProgress = false)
       }"
       title="Download Progress"
     >
@@ -874,26 +877,26 @@ class ArchiveWebApp extends ReplayWebApp {
           Downloading to:
           <i
             >${
-              // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
-              this.download.filename
-            }</i
+      // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
+      this.download.filename
+      }</i
           >
         </div>
         <div>
           Size Downloaded:
           <b
             >${
-              // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
-              prettyBytes(this.download.currSize)
-            }</b
+      // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
+      prettyBytes(this.download.currSize)
+      }</b
           >
         </div>
         <div>
           Time Elapsed:
           ${
-            // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
-            Math.round(Date.now() / 1000 - this.download.startTime)
-          }
+      // @ts-expect-error - TS2339 - Property 'download' does not exist on type 'ArchiveWebApp'.
+      Math.round(Date.now() / 1000 - this.download.startTime)
+      }
           seconds
         </div>
 
@@ -948,9 +951,8 @@ class ArchiveWebApp extends ReplayWebApp {
           <div class="modal-card">
             <header class="modal-card-head">
               <p class="modal-card-title">About ArchiveWeb.page ${this.getDeployType()}</p>
-              <button class="delete" aria-label="close" @click="${
-                this.onAboutClose
-              }"></button>
+              <button class="delete" aria-label="close" @click="${this.onAboutClose
+      }"></button>
             </header>
             <section class="modal-card-body">
               <div class="container">
@@ -961,20 +963,19 @@ class ArchiveWebApp extends ReplayWebApp {
                       <div style="font-size: smaller; margin-bottom: 1em">${this.getDeployType()} v${VERSION}</div>
                     </div>
 
-                    ${
-                      IS_APP
-                        ? html`
+                    ${IS_APP
+        ? html`
                             <p>
                               ArchiveWeb.page App is a standalone app for Mac,
                               Windows and Linux that allows users to archive
                               webpages as they browse
                             </p>
                           `
-                        : html` <p>
+        : html` <p>
                             ArchiveWeb.page allows users to archive webpages
                             directly in your browser!
                           </p>`
-                    }
+      }
                   </div>
 
                   <p>See the <a href="https://archiveweb.page/guide" target="_blank">ArchiveWeb.page Guide</a> for more info on how to use this tool.</p>
@@ -1004,9 +1005,8 @@ class ArchiveWebApp extends ReplayWebApp {
                   </details>
 
                   <div class="has-text-centered">
-                    <a class="button is-warning" href="#" @click="${
-                      this.onAboutClose
-                    }">Close</a>
+                    <a class="button is-warning" href="#" @click="${this.onAboutClose
+      }">Close</a>
                   </div>
                 </div>
               </div>
@@ -1044,7 +1044,7 @@ class ArchiveWebApp extends ReplayWebApp {
           @submit="${this.onSaveSettings}"
         >
           ${this.settingsTab === "prefs"
-            ? html`<fieldset>
+        ? html`<fieldset>
                 <div class="is-size-6 mt-4">Optional archiving features:</div>
                 <div class="field is-size-6 mt-4">
                   <input
@@ -1162,9 +1162,9 @@ class ArchiveWebApp extends ReplayWebApp {
                   </p>
                 </div>
               </fieldset>`
-            : ``}
+        : ``}
           ${this.settingsTab === "ipfs"
-            ? html` <p class="is-size-6 mb-3">
+        ? html` <p class="is-size-6 mb-3">
                   Configure settings for sharing archived items to IPFS.
                 </p>
                 <fieldset>
@@ -1204,9 +1204,9 @@ class ArchiveWebApp extends ReplayWebApp {
                     </p>
                   </div>
                 </fieldset>`
-            : ""}
+        : ""}
           ${this.settingsTab === "browsertrix"
-            ? html`
+        ? html`
                 <p class="is-size-6 mb-3">
                   Configure your credentials to upload archived items to
                   Browsertrix: Webrecorder's cloud-based crawling service.
@@ -1272,12 +1272,12 @@ class ArchiveWebApp extends ReplayWebApp {
                   </div>
                 </fieldset>
               `
-            : ""}
+        : ""}
           <div class="has-text-centered has-text-danger">
             ${this.settingsError}
           </div>
           ${this.settingsTab !== "prefs"
-            ? html`<div class="has-text-centered mt-4">
+        ? html`<div class="has-text-centered mt-4">
                 <button class="button is-primary" type="submit">Save</button>
                 <button
                   class="button"
@@ -1287,7 +1287,7 @@ class ArchiveWebApp extends ReplayWebApp {
                   Cancel
                 </button>
               </div>`
-            : ``}
+        : ``}
         </form>
       </wr-modal>
     `;
@@ -1375,8 +1375,8 @@ class ArchiveWebApp extends ReplayWebApp {
   // @ts-expect-error - TS7006 - Parameter 'event' implicitly has an 'any' type.
   onShowStart(event) {
     this._setCurrColl(event);
-    // @ts-expect-error - TS2339 - Property 'recordUrl' does not exist on type 'ArchiveWebApp'.
-    this.recordUrl = event.detail.url || "https://example.com/";
+    // @ts-expect-error - TS2339 - Property 'recordUrl' does not exist on type 'ArchiveWebApp'. | TS2339 - Property 'startPage' does not exist on type 'ArchiveWebApp'.
+    this.recordUrl = event.detail.url || this.startPage;
     // @ts-expect-error - TS2551 - Property 'showStartRecord' does not exist on type 'ArchiveWebApp'. Did you mean 'onStartRecord'?
     this.showStartRecord = true;
   }

--- a/src/ui/coll.ts
+++ b/src/ui/coll.ts
@@ -1,3 +1,4 @@
+
 import {
   html,
   css,
@@ -11,12 +12,14 @@ import fasUnfullscreen from "@fortawesome/fontawesome-free/svgs/solid/compress-a
 
 import { type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 import prettyBytes from "pretty-bytes";
 
 import { Item } from "replaywebpage";
 
 import wrRec from "../assets/icons/recLogo.svg";
+import "./rec-resources";
 
 //============================================================================
 class WrRecColl extends Item {
@@ -145,8 +148,8 @@ class WrRecColl extends Item {
         href="#"
         role="button"
         class="${!isDropdown
-          ? "button narrow is-borderless"
-          : "dropdown-item is-hidden-tablet"}"
+        ? "button narrow is-borderless"
+        : "dropdown-item is-hidden-tablet"}"
         title="Start Archiving"
         aria-label="Start Archiving"
         aria-controls="record"
@@ -193,14 +196,14 @@ class WrRecColl extends Item {
           <span class="size-label">${prettyBytes(this.totalSize)}</span>
         </span>
         ${this.showFinish
-          ? html` <button
+        ? html` <button
               class="button is-primary-new"
               @click="${this.onEmbedFinish}"
               type="button"
             >
               Finish
             </button>`
-          : html`
+        : html`
               <a
                 class="button is-primary-new"
                 role="button"
@@ -211,6 +214,71 @@ class WrRecColl extends Item {
               >
             `}
       </div>
+    `;
+  }
+
+  // @ts-expect-error - TS7006 - Parameter 'isSidebar' implicitly has an 'any' type.
+  renderItemTabs(isSidebar) {
+    const isStory = this.hasStory && this.tabData.view === "story";
+    const isPages = this.tabData.view === "pages";
+    const isResources = this.tabData.view === "resources";
+
+    return html`
+      ${isStory
+        ? html` <wr-coll-story
+            .collInfo="${this.itemInfo || {}}"
+            .active="${isStory}"
+            currList="${this.tabData.currList || 0}"
+            @coll-tab-nav="${this.onItemTabNav}"
+            id="story"
+            .isSidebar="${isSidebar}"
+            class="${
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          isStory ? "" : "is-hidden"
+          } ${isSidebar ? "sidebar" : ""}"
+            role="${ifDefined(isSidebar ? undefined : "main")}"
+          >
+          </wr-coll-story>`
+        : ""}
+      ${isResources
+        ? html` <wr-rec-resources
+            .collInfo="${this.itemInfo || {}}"
+            .active="${isResources}"
+            query="${this.tabData.query || ""}"
+            urlSearchType="${this.tabData.urlSearchType || ""}"
+            .currMime="${this.tabData.currMime || ""}"
+            @coll-tab-nav="${this.onItemTabNav}"
+            id="resources"
+            .isSidebar="${isSidebar}"
+            class="is-paddingless ${
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          isResources ? "" : "is-hidden"
+          } ${isSidebar ? "sidebar" : ""}"
+            role="${ifDefined(isSidebar ? undefined : "main")}"
+          >
+          </wr-rec-resources>`
+        : ""}
+      ${isPages
+        ? html` <wr-page-view
+            .collInfo="${this.itemInfo}"
+            .active="${isPages}"
+            .editable="${this.editable}"
+            .isSidebar="${isSidebar}"
+            currList="${this.tabData.currList || 0}"
+            query="${this.tabData.query || ""}"
+            .url="${this.tabData.url || ""}"
+            .ts="${this.tabData.ts || ""}"
+            @coll-tab-nav="${this.onItemTabNav}"
+            id="pages"
+            @coll-update="${this.onItemUpdate}"
+            class="${
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          isPages ? "" : "is-hidden"
+          } ${isSidebar ? "sidebar" : ""}"
+            role="${ifDefined(isSidebar ? undefined : "main")}"
+          >
+          </wr-page-view>`
+        : ""}
     `;
   }
 

--- a/src/ui/rec-resources.ts
+++ b/src/ui/rec-resources.ts
@@ -1,0 +1,304 @@
+import { html, css } from "lit";
+import {
+    URLResources,
+    wrapCss,
+    clickOnSpacebarPress,
+    getReplayLink,
+    getDownloadLink,
+    dateTimeFormatter,
+} from "replaywebpage";
+
+import fasSearch from "@fortawesome/fontawesome-free/svgs/solid/search.svg";
+import fasDownload from "@fortawesome/fontawesome-free/svgs/solid/download.svg";
+
+import { ifDefined } from "lit/directives/if-defined.js";
+
+class RecUrlResources extends URLResources {
+    static get sortKeys() {
+        return [
+            ...super.sortKeys,
+            {
+                key: "digest",
+                name: "Digest",
+            },
+        ];
+    }
+
+    static get styles() {
+        return [
+            super.styles,
+            css`
+        .col-digest {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      `,
+        ];
+    }
+
+    render() {
+        return html`
+      <div
+        role="heading"
+        aria-level="${this.isSidebar ? "2" : "1"}"
+        class="is-sr-only"
+      >
+        URLs in ${this.collInfo!.title}
+      </div>
+
+      <div
+        role="heading"
+        aria-level="${this.isSidebar ? "3" : "2"}"
+        class="is-sr-only"
+      >
+        Search and Filter
+      </div>
+      <div class="notification level is-marginless">
+        <div class="level-left flex-auto">
+          <div class="level-item flex-auto">
+            <span class="is-hidden-mobile">Search:&nbsp;&nbsp;</span>
+            <div class="select">
+              <select @change="${this.onChangeTypeSearch}">
+                ${URLResources.filters.map(
+            (filter) => html`
+                    <option
+                      value="${filter.filter}"
+                      ?selected="${filter.filter === this.currMime}"
+                    >
+                      ${filter.name}
+                    </option>
+                  `
+        )}
+              </select>
+            </div>
+            <div class="field flex-auto">
+              <div
+                class="control has-icons-left ${this.loading
+                ? "is-loading"
+                : ""}"
+              >
+                <input
+                  type="text"
+                  class="input"
+                  @input="${this.onChangeQuery}"
+                  .value="${this.query}"
+                  placeholder="Enter URL to Search"
+                />
+                <span class="icon is-left"
+                  ><fa-icon .svg="${fasSearch}"></fa-icon
+                ></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="control level-right">
+          <div style="margin-left: 1em" class="control">
+            <label class="radio has-text-left"
+              ><input
+                type="radio"
+                name="urltype"
+                value="contains"
+                ?checked="${this.urlSearchType === "contains"}"
+                @click="${this.onClickUrlType}"
+              />&nbsp;Contains</label
+            >
+            <label class="radio has-text-left"
+              ><input
+                type="radio"
+                name="urltype"
+                value="prefix"
+                ?checked="${this.urlSearchType === "prefix"}"
+                @click="${this.onClickUrlType}"
+              />&nbsp;Prefix</label
+            >
+            <label class="radio has-text-left"
+              ><input
+                type="radio"
+                name="urltype"
+                value="exact"
+                ?checked="${this.urlSearchType === "exact"}"
+                @click="${this.onClickUrlType}"
+              />&nbsp;Exact</label
+            >
+            <span
+              id="num-results"
+              class="num-results"
+              is-pulled-right
+              aria-live="polite"
+              aria-atomic="true"
+              >${this.filteredResults.length} Result(s)</span
+            >
+          </div>
+        </div>
+      </div>
+
+      <div class="sort-header is-hidden-tablet">
+        <wr-sorter
+          id="urls"
+          .sortKey="${this.sortKey}"
+          .sortDesc="${this.sortDesc}"
+          .sortKeys="${RecUrlResources.sortKeys}"
+          .data="${this.filteredResults}"
+          @sort-changed="${this.onSortChanged}"
+        >
+        </wr-sorter>
+      </div>
+
+      <div
+        role="heading"
+        aria-level="${this.isSidebar ? "3" : "2"}"
+        id="results-heading"
+        class="is-sr-only"
+      >
+        Results
+      </div>
+
+      <table class="all-results" aria-labelledby="results-heading num-results">
+        <thead>
+          <tr class="columns results-head has-text-weight-bold">
+            <th scope="col" class="column col-url is-5 is-hidden-mobile">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSort}"
+                @keyup="${clickOnSpacebarPress}"
+                data-key="url"
+                class="${this.sortKey === "url"
+                ? this.sortDesc
+                    ? "desc"
+                    : "asc"
+                : ""}"
+                >URL</a
+              >
+            </th>
+            <th scope="col" class="column col-ts is-2 is-hidden-mobile">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSort}"
+                @keyup="${clickOnSpacebarPress}"
+                data-key="ts"
+                class="${this.sortKey === "ts"
+                ? this.sortDesc
+                    ? "desc"
+                    : "asc"
+                : ""}"
+                >Date</a
+              >
+            </th>
+            <th scope="col" class="column col-mime is-2 is-hidden-mobile">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSort}"
+                @keyup="${clickOnSpacebarPress}"
+                data-key="mime"
+                class="${this.sortKey === "mime"
+                ? this.sortDesc
+                    ? "desc"
+                    : "asc"
+                : ""}"
+                >Media Type</a
+              >
+            </th>
+            <th scope="col" class="column col-status is-1 is-hidden-mobile">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSort}"
+                @keyup="${clickOnSpacebarPress}"
+                data-key="status"
+                class="${this.sortKey === "status"
+                ? this.sortDesc
+                    ? "desc"
+                    : "asc"
+                : ""}"
+                >Status</a
+              >
+            </th>
+             <th scope="col" class="column col-digest is-2 is-hidden-mobile">
+              <a
+                role="button"
+                href="#"
+                @click="${this.onSort}"
+                @keyup="${clickOnSpacebarPress}"
+                data-key="digest"
+                class="${this.sortKey === "digest"
+                ? this.sortDesc
+                    ? "desc"
+                    : "asc"
+                : ""}"
+                >Digest</a
+              >
+            </th>
+          </tr>
+        </thead>
+
+        <tbody class="main-scroll" @scroll="${this.onScroll}">
+          ${this.sortedResults.length
+                ? this.sortedResults.map(
+                    (result) => html`
+                  <tr class="columns result">
+                    <td class="column col-url is-5">
+                      <p class="minihead is-hidden-tablet">URL</p>
+                      <a
+                        class="dl-button"
+                        href="${getDownloadLink(
+                        this.collInfo!.replayPrefix,
+                        result.url,
+                        result.ts
+                    )}"
+                        ><fa-icon
+                          size="1.0em"
+                          class="has-text-black"
+                          aria-hidden="true"
+                          title="Download Resource"
+                          .svg="${fasDownload}"
+                        ></fa-icon>
+                      </a>
+                      <a
+                        @click="${this.onReplay}"
+                        data-url="${result.url}"
+                        data-ts="${result.ts}"
+                        href="${getReplayLink(
+                        "resources",
+                        result.url,
+                        result.ts
+                    )}"
+                      >
+                        <keyword-mark keywords="${this.query}"
+                          >${result.url}</keyword-mark
+                        >
+                      </a>
+                    </td>
+                    <td class="column col-ts is-2">
+                      <p class="minihead is-hidden-tablet">Date</p>
+                      ${dateTimeFormatter.format(new Date(result.date))}
+                    </td>
+                    <td class="column col-mime is-2">
+                      <p class="minihead is-hidden-tablet">Media Type</p>
+                      ${result.mime}
+                    </td>
+                    <td class="column col-status is-1">
+                      <p class="minihead is-hidden-tablet">Status</p>
+                      ${result.status}
+                    </td>
+                    <td class="column col-digest is-2" title="${ifDefined((result as any).digest)}">
+                      <p class="minihead is-hidden-tablet">Digest</p>
+                      ${(result as any).digest}
+                    </td>
+                  </tr>
+                `
+                )
+                : html`<tr class="section">
+                <td colspan="5"><i>No Results Found.</i></td>
+              </tr>`}
+        </tbody>
+      </table>
+    `;
+    }
+}
+
+customElements.define("wr-rec-resources", RecUrlResources);
+
+export { RecUrlResources };


### PR DESCRIPTION
### Changes

## 1.Description

I added a new **lock icon** next to the favicon in the address bar. Clicking this icon now opens a popup displaying the full SSL certificate details of the current page.

<img width="1700" height="1152" alt="image" src="https://github.com/user-attachments/assets/2ff538aa-334f-435a-ada4-216c2683916e" />


### Motivation
This feature is particularly useful for users who perform **screen recordings** during their archiving sessions. It allows them to visually inspect and record the certificate's validity in real-time, providing an extra layer of verification/proof within the video capture itself.


=======


## 2.Description
This adds a new "Digest" column to the Resources table, allowing users to view the SHA-256 hash of captured resources directly in the UI.

<img width="3840" height="2114" alt="image" src="https://github.com/user-attachments/assets/10401681-c674-41c1-82b3-b5bd5f9656bf" />

### Motivation
This feature is essential for digital forensics and archival integrity. Displaying the SHA-256 digest allows users to verify that the captured resources are authentic and have not been altered. 