### PR TITLE
store detected content-type for browser in WARC-Identified-Payload-Type to avoid encoding issues 

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1674,6 +1674,8 @@ class Recorder {
           if (storage) {
             data.extraOpts.storage = storage;
           }
+
+          await this.saveDetectedContentType(reqresp, sessions);
         }
       }
 
@@ -1687,6 +1689,27 @@ class Recorder {
 
     //doneResolve();
     //delete this._fetchPending[requestId];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async saveDetectedContentType(reqresp: RequestResponseInfo, sessions: any) {
+    try {
+      // @ts-expect-error: types not yet defined
+      const { result } = await this.send("Runtime.evaluate",  {
+        expression:
+          "`${document.contentType}; charset=${document.characterSet}`",
+        returnByValue: true,
+      }, sessions);
+
+      const contentType = result.value;
+
+      // only save charset if its not the default UTF-8
+      if (contentType && contentType !== "text/html; charset=UTF-8") {
+        reqresp.extraOpts.detectedCT = contentType;
+      }
+    } catch (e) {
+      console.warn("Error getting detected content-type", e);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/sw/downloader.ts
+++ b/src/sw/downloader.ts
@@ -1034,7 +1034,12 @@ class Downloader {
     }
 
     if (extraOpts && Object.keys(extraOpts).length) {
-      warcHeaders["WARC-JSON-Metadata"] = JSON.stringify(resource.extraOpts);
+      if (extraOpts.detectedCT) {
+        warcHeaders["WARC-Identified-Payload-Type"] = extraOpts.detectedCT;
+        delete extraOpts.detectedCT;
+      }
+
+      warcHeaders["WARC-JSON-Metadata"] = JSON.stringify(extraOpts);
     }
 
     if (refersToDigest) {


### PR DESCRIPTION
- capture impl of issue describe in webrecorder/replayweb.page#541
- port of webrecorder/browsertrix-crawler#1143 to AWP
- store detected content-type from the browser (`${document.contentType}; charset=${document.characterSet}`) in extraOpts
- when serializing to WARC, store in WARC-Identified-Payload-Type as per iipc/warc-specifications#121