### PR TITLE
downloader: don't add pageId to request record if it is empty

### DIFF
--- a/src/sw/downloader.ts
+++ b/src/sw/downloader.ts
@@ -68,7 +68,7 @@ type DLResourceEntry = ResourceEntry & {
   skipped?: boolean;
   text?: string;
 
-  pageId: string;
+  pageId?: string;
   digest: string;
 };
 
@@ -1096,9 +1096,12 @@ class Downloader {
         "WARC-Record-ID": this.getWARCRecordUUID(
           type + ":" + resource.timestamp + "/" + resource.url,
         ),
-        "WARC-Page-ID": pageId,
         "WARC-Concurrent-To": responseRecordId,
       };
+
+      if (pageId) {
+        reqWarcHeaders["WARC-Page-ID"] = pageId;
+      }
 
       const urlParsed = new URL(url);
       const statusline = `${method} ${url.slice(


### PR DESCRIPTION
- for response, we skip the pageId if it is empty/undefined. do the same for request.
- type: change type of pageId to string or undefined to better detect, as it may not be defined if imported from WARCs
- fixes #374